### PR TITLE
fix close race condition between pthread_join and libqcow2 call

### DIFF
--- a/drivers/block-qcow2.c
+++ b/drivers/block-qcow2.c
@@ -235,7 +235,7 @@ qcow2_initialize(struct qcow2_state *s, Error **perr)
 }
 
 static void
-qcow2_free(struct qcow2_state *s)
+qcow2_deinit()
 {
         qemu_deinit_main_loop();
 
@@ -472,7 +472,7 @@ qcow2_open(void *opaque)
 
     drain_call_rcu();
 
-    qcow2_free(s);
+    qcow2_deinit();
 
     return NULL;
 fail:
@@ -486,7 +486,7 @@ fail1:
     pthread_cond_signal(&s->cond);
     pthread_mutex_unlock(&s->lock);
 
-    qcow2_free(s);
+    qcow2_deinit();
     return NULL;
 }
 

--- a/drivers/block-qcow2.c
+++ b/drivers/block-qcow2.c
@@ -474,6 +474,10 @@ qcow2_open(void *opaque)
 
     qcow2_deinit();
 
+    pthread_mutex_lock(&s->lock);
+    pthread_cond_signal(&s->cond);
+    pthread_mutex_unlock(&s->lock);
+
     return NULL;
 fail:
     blk_unref(conf->blk);
@@ -481,12 +485,13 @@ fail1:
     EPRINTF("open error: %s\n", error_get_pretty(local_err));
     error_free(local_err);
 
+    qcow2_deinit();
+
     pthread_mutex_lock(&s->lock);
     s->open_status = -EINVAL;
     pthread_cond_signal(&s->cond);
     pthread_mutex_unlock(&s->lock);
 
-    qcow2_deinit();
     return NULL;
 }
 
@@ -551,6 +556,10 @@ _qcow2_close(td_driver_t *driver)
     pthread_mutex_unlock(&s->lock);
 
     qemu_bh_schedule(s->bh);
+
+    pthread_mutex_lock(&s->lock);
+    pthread_cond_wait(&s->cond, &s->lock);
+    pthread_mutex_unlock(&s->lock);
 
     // Ignore return, qcow2_open() always return NULL; or will abort
     qemu_thread_join(&s->thread);


### PR DESCRIPTION
```
Thread 3 "tapdisk" hit Catchpoint 2 (call to syscall exit_group), 0x00007f64e4909a31 in _exit () from /lib64/ld-linux-x86-64.so.2
(gdb) bt
#0  0x00007f64e4909a31 in _exit () from /lib64/ld-linux-x86-64.so.2
#1  0x00007f64e48ff7fa in _dl_signal_error () from /lib64/ld-linux-x86-64.so.2
#2  0x00007f64e48ff8ae in _dl_signal_cerror () from /lib64/ld-linux-x86-64.so.2
#3  0x00007f64e48fab1a in _dl_lookup_symbol_x () from /lib64/ld-linux-x86-64.so.2
#4  0x00007f64e48fef1e in _dl_fixup () from /lib64/ld-linux-x86-64.so.2
#5  0x00007f64e4906b2a in _dl_runtime_resolve_xsave () from /lib64/ld-linux-x86-64.so.2
#6  0x0000000000427731 in qcow2_free (s=0x1a2c500) at block-qcow2.c:243
#7  qcow2_open (opaque=0x1a2c500) at block-qcow2.c:475
#8  0x00007f64e4a965ae in qemu_thread_start (args=0x19b9540) at util/qemu-thread-posix.c:543
#9  0x00007f64e46dbe25 in start_thread () from /lib64/libpthread.so.0
#10 0x00007f64e2dcfbad in clone () from /lib64/libc.so.6
(gdb) info threads
  Id   Target Id                                    Frame
  1    Thread 0x7f64e49bb980 (LWP 335962) "tapdisk" 0x00007f64e46dcf97 in pthread_join () from /lib64/libpthread.so.0
  2    Thread 0x7f64e1c54700 (LWP 335963) "tapdisk" 0x00007f64e46e2f3d in nanosleep () from /lib64/libpthread.so.0
* 3    Thread 0x7f64e12f2700 (LWP 335967) "tapdisk" 0x00007f64e4909a31 in _exit () from /lib64/ld-linux-x86-64.so.2
(gdb) thread 1
[Switching to thread 1 (Thread 0x7f64e49bb980 (LWP 335962))]
#0  0x00007f64e46dcf97 in pthread_join () from /lib64/libpthread.so.0
(gdb) bt
#0  0x00007f64e46dcf97 in pthread_join () from /lib64/libpthread.so.0
#1  0x00007f64e4a96aa7 in qemu_thread_join (thread=0x1a3f9a0) at util/qemu-thread-posix.c:683
#2  0x0000000000427cf9 in _qcow2_close (driver=<optimized out>) at block-qcow2.c:556
#3  0x0000000000412e7e in td_close (image=image@entry=0x19e5250) at tapdisk-interface.c:126
#4  0x0000000000411b99 in tapdisk_image_close (image=0x19e5250) at tapdisk-image.c:189
#5  0x0000000000411d78 in tapdisk_image_close_chain (list=list@entry=0x19e4d80) at tapdisk-image.c:291
#6  0x000000000040967f in tapdisk_vbd_close_vdi (vbd=0x19e4d40) at tapdisk-vbd.c:274
#7  0x000000000040a687 in tapdisk_vbd_pause (vbd=vbd@entry=0x19e4d40) at tapdisk-vbd.c:1047
#8  0x0000000000406143 in tapdisk_control_pause_vbd (conn=<optimized out>, request=<optimized out>, response=<optimized out>) at tapdisk-control.c:1014
#9  0x0000000000407538 in tapdisk_control_process_request (event_id=<optimized out>, mode=<optimized out>, private=<optimized out>) at tapdisk-control.c:1556
#10 0x000000000042cd9e in scheduler_event_callback (mode=1 '\001', event=0x1a4a5c0, s=0x0) at scheduler.c:241
#11 scheduler_run_events (s=s@entry=0x447298 <server+24>) at scheduler.c:262
#12 0x000000000042d555 in scheduler_wait_for_events (s=<optimized out>, s@entry=0x447298 <server+24>) at scheduler.c:457
#13 0x0000000000413d47 in tapdisk_server_iterate () at tapdisk-server.c:412
#14 0x0000000000414335 in __tapdisk_server_run () at tapdisk-server.c:429
#15 tapdisk_server_run () at tapdisk-server.c:899
#16 0x0000000000404f57 in main (argc=<optimized out>, argv=<optimized out>) at tapdisk2.c:160
```