### PR TITLE
Introduce new features support in tapdisk-messages

### DIFF
--- a/control/tap-ctl-info.c
+++ b/control/tap-ctl-info.c
@@ -25,7 +25,8 @@
 #include "tap-ctl.h"
 
 int tap_ctl_info(pid_t pid, unsigned long long *sectors,
-		unsigned int *sector_size, unsigned int *info, const int minor)
+                 unsigned int *sector_size, unsigned int *info, unsigned int *max_queues,
+                 const int minor)
 {
     tapdisk_message_t message;
     int err;
@@ -49,6 +50,7 @@ int tap_ctl_info(pid_t pid, unsigned long long *sectors,
         *sectors = message.u.image.sectors;
         *sector_size = message.u.image.sector_size;
         *info = message.u.image.info;
+        *max_queues = message.u.image.max_queues;
         return 0;
     } else if (TAPDISK_MESSAGE_ERROR == message.type) {
        return -message.u.response.error;

--- a/control/tap-ctl-info.c
+++ b/control/tap-ctl-info.c
@@ -26,6 +26,7 @@
 
 int tap_ctl_info(pid_t pid, unsigned long long *sectors,
                  unsigned int *sector_size, unsigned int *info, unsigned int *max_queues,
+                 bool *discard, unsigned int *discard_granularity,
                  const int minor)
 {
     tapdisk_message_t message;
@@ -34,10 +35,12 @@ int tap_ctl_info(pid_t pid, unsigned long long *sectors,
     ASSERT(sectors);
     ASSERT(sector_size);
     ASSERT(info);
+    ASSERT(discard);
+    ASSERT(discard_granularity);
 
     memset(&message, 0, sizeof(message));
     message.type = TAPDISK_MESSAGE_DISK_INFO;
-	message.cookie = minor;
+    message.cookie = minor;
 
     err = tap_ctl_connect_send_and_receive(pid, &message, NULL);
     if (err) {
@@ -51,6 +54,8 @@ int tap_ctl_info(pid_t pid, unsigned long long *sectors,
         *sector_size = message.u.image.sector_size;
         *info = message.u.image.info;
         *max_queues = message.u.image.max_queues;
+        *discard = message.u.image.discard;
+        *discard_granularity = message.u.image.discard_granularity;
         return 0;
     } else if (TAPDISK_MESSAGE_ERROR == message.type) {
        return -message.u.response.error;

--- a/control/tap-ctl-xen.c
+++ b/control/tap-ctl-xen.c
@@ -60,6 +60,7 @@ tap_ctl_connect_xenblkif(const pid_t pid, const domid_t domid, const int devid, 
     message.u.blkif.ports[0] = port;
     message.u.blkif.proto = proto;
     message.u.blkif.persistent_grants = false;
+    message.u.blkif.indirect_max_segments = 0;
     message.u.blkif.poll_duration = poll_duration;
     message.u.blkif.poll_idle_threshold = poll_idle_threshold;
     if (pool_name) {

--- a/control/tap-ctl-xen.c
+++ b/control/tap-ctl-xen.c
@@ -59,6 +59,7 @@ tap_ctl_connect_xenblkif(const pid_t pid, const domid_t domid, const int devid, 
     message.u.blkif.order = order;
     message.u.blkif.ports[0] = port;
     message.u.blkif.proto = proto;
+    message.u.blkif.persistent_grants = false;
     message.u.blkif.poll_duration = poll_duration;
     message.u.blkif.poll_idle_threshold = poll_idle_threshold;
     if (pool_name) {

--- a/control/tap-ctl-xen.c
+++ b/control/tap-ctl-xen.c
@@ -47,16 +47,17 @@ tap_ctl_connect_xenblkif(const pid_t pid, const domid_t domid, const int devid, 
     tapdisk_message_t message;
     int i, err;
 
-	memset(&message, 0, sizeof(message));
+    memset(&message, 0, sizeof(message));
     message.type = TAPDISK_MESSAGE_XENBLKIF_CONNECT;
     message.cookie = minor;
 
     message.u.blkif.domid = domid;
     message.u.blkif.devid = devid;
     for (i = 0; i < 1 << order; i++)
-        message.u.blkif.gref[i] = grefs[i];
+        message.u.blkif.gref[0][i] = grefs[i];
+    message.u.blkif.nr_queues = 1;
     message.u.blkif.order = order;
-    message.u.blkif.port = port;
+    message.u.blkif.ports[0] = port;
     message.u.blkif.proto = proto;
     message.u.blkif.poll_duration = poll_duration;
     message.u.blkif.poll_idle_threshold = poll_idle_threshold;

--- a/drivers/tapdisk-control.c
+++ b/drivers/tapdisk-control.c
@@ -1236,11 +1236,11 @@ tapdisk_control_xenblkif_connect(
     } else
         pool_name = blkif->pool_name;
 
-    DPRINTF("connecting VBD %d domid=%d, devid=%d, pool %s, evt %d, poll duration %d, poll idle threshold %d\n",
-            vbd->uuid, blkif->domid, blkif->devid, pool_name, blkif->port, blkif->poll_duration, blkif->poll_idle_threshold);
+    DPRINTF("connecting VBD %d domid=%d, devid=%d, queues=%d, pool %s, evt %d, poll duration %d, poll idle threshold %d\n",
+            vbd->uuid, blkif->domid, blkif->devid, blkif->nr_queues, pool_name, blkif->ports[0], blkif->poll_duration, blkif->poll_idle_threshold);
 
-    err = tapdisk_xenblkif_connect(blkif->domid, blkif->devid, blkif->gref,
-            blkif->order, blkif->port, blkif->proto, blkif->poll_duration, blkif->poll_idle_threshold, pool_name, vbd);
+    err = tapdisk_xenblkif_connect(blkif->domid, blkif->devid, &blkif->gref[0][0],
+            blkif->order, blkif->ports[0], blkif->proto, blkif->poll_duration, blkif->poll_idle_threshold, pool_name, vbd);
 
 out:
 	response->cookie = request->cookie;

--- a/drivers/tapdisk-control.c
+++ b/drivers/tapdisk-control.c
@@ -1238,11 +1238,17 @@ tapdisk_control_xenblkif_connect(
     } else
         pool_name = blkif->pool_name;
 
-    DPRINTF("connecting VBD %d domid=%d, devid=%d, queues=%d, pool %s, evt %d, poll duration %d, poll idle threshold %d\n",
-            vbd->uuid, blkif->domid, blkif->devid, blkif->nr_queues, pool_name, blkif->ports[0], blkif->poll_duration, blkif->poll_idle_threshold);
+    DPRINTF("connecting VBD %d domid=%d, devid=%d, queues=%d,"
+	    " persistent-grants=%s,"
+	    " pool %s, evt %d, poll duration %d, poll idle threshold %d\n",
+	    vbd->uuid, blkif->domid, blkif->devid, blkif->nr_queues,
+	    blkif->persistent_grants ? "yes":"no",
+	    pool_name, blkif->ports[0], blkif->poll_duration, blkif->poll_idle_threshold);
 
     err = tapdisk_xenblkif_connect(blkif->domid, blkif->devid, &blkif->gref[0][0],
-            blkif->order, blkif->ports[0], blkif->proto, blkif->poll_duration, blkif->poll_idle_threshold, pool_name, vbd);
+				blkif->order, blkif->ports[0], blkif->persistent_grants,
+				blkif->proto, blkif->poll_duration, blkif->poll_idle_threshold,
+				pool_name, vbd);
 
 out:
 	response->cookie = request->cookie;

--- a/drivers/tapdisk-control.c
+++ b/drivers/tapdisk-control.c
@@ -1240,13 +1240,16 @@ tapdisk_control_xenblkif_connect(
 
     DPRINTF("connecting VBD %d domid=%d, devid=%d, queues=%d,"
 	    " persistent-grants=%s,"
+	    " indirect-segs=%s (max %d),"
 	    " pool %s, evt %d, poll duration %d, poll idle threshold %d\n",
 	    vbd->uuid, blkif->domid, blkif->devid, blkif->nr_queues,
 	    blkif->persistent_grants ? "yes":"no",
+	    blkif->indirect_max_segments ? "enabled":"disabled", blkif->indirect_max_segments,
 	    pool_name, blkif->ports[0], blkif->poll_duration, blkif->poll_idle_threshold);
 
     err = tapdisk_xenblkif_connect(blkif->domid, blkif->devid, &blkif->gref[0][0],
 				blkif->order, blkif->ports[0], blkif->persistent_grants,
+				blkif->indirect_max_segments,
 				blkif->proto, blkif->poll_duration, blkif->poll_idle_threshold,
 				pool_name, vbd);
 

--- a/drivers/tapdisk-control.c
+++ b/drivers/tapdisk-control.c
@@ -846,6 +846,8 @@ out:
         response->u.image.sectors = vbd->disk_info.size;
         response->u.image.sector_size = vbd->disk_info.sector_size;
         response->u.image.info = vbd->disk_info.info;
+        response->u.image.discard = vbd->disk_info.discard;
+        response->u.image.discard_granularity = vbd->disk_info.discard_granularity;
         response->type = TAPDISK_MESSAGE_OPEN_RSP;
 		return td_err_set_success(error);
 	}
@@ -1302,17 +1304,21 @@ tapdisk_control_disk_info(
     if (!vbd) {
         err = -ENODEV;
         goto out;
-	}
+    }
 
-    DPRINTF("VBD %d got disk info: sectors=%llu sector size=%ld, info=%d\n",
+    DPRINTF("VBD %d got disk info: sectors=%llu sector size=%ld, info=%d, discard=%s, discard granularity=%ld\n",
             vbd->uuid, (unsigned long long)vbd->disk_info.size,
-            vbd->disk_info.sector_size, vbd->disk_info.info);
+            vbd->disk_info.sector_size, vbd->disk_info.info,
+            vbd->disk_info.discard ? "true" : "false",
+            vbd->disk_info.discard_granularity);
 out:
     if (!err) {
         response->type = TAPDISK_MESSAGE_DISK_INFO_RSP;
         image->sectors = vbd->disk_info.size;
         image->sector_size = vbd->disk_info.sector_size;
         image->info = vbd->disk_info.info;
+        image->discard = vbd->disk_info.discard;
+        image->discard_granularity = vbd->disk_info.discard_granularity;
     }
     return td_err_set_errno(error, err);
 }

--- a/drivers/tapdisk.h
+++ b/drivers/tapdisk.h
@@ -141,6 +141,8 @@ struct td_disk_info {
 	td_sector_t                  size;
 	long                         sector_size;
 	uint32_t                     info;
+	bool                         discard;
+	long                         discard_granularity;
 };
 
 struct td_iovec {

--- a/drivers/td-blkif.c
+++ b/drivers/td-blkif.c
@@ -428,6 +428,7 @@ tapdisk_xenblkif_cb_chkrng(event_id_t id __attribute__((unused)),
 int
 tapdisk_xenblkif_connect(domid_t domid, int devid, const grant_ref_t * grefs,
                          int order, evtchn_port_t port, bool persistent_grant,
+                         unsigned int indirect_max_segments,
                          int proto, int poll_duration, int poll_idle_threshold,
                          const char *pool, td_vbd_t * vbd)
 {

--- a/drivers/td-blkif.c
+++ b/drivers/td-blkif.c
@@ -427,8 +427,9 @@ tapdisk_xenblkif_cb_chkrng(event_id_t id __attribute__((unused)),
 
 int
 tapdisk_xenblkif_connect(domid_t domid, int devid, const grant_ref_t * grefs,
-        int order, evtchn_port_t port, int proto, int poll_duration,
-        int poll_idle_threshold, const char *pool, td_vbd_t * vbd)
+                         int order, evtchn_port_t port, bool persistent_grant,
+                         int proto, int poll_duration, int poll_idle_threshold,
+                         const char *pool, td_vbd_t * vbd)
 {
     struct td_xenblkif *td_blkif = NULL; /* TODO rename to blkif */
     struct td_xenio_ctx *td_ctx;

--- a/drivers/td-blkif.h
+++ b/drivers/td-blkif.h
@@ -223,6 +223,7 @@ struct td_xenblkif {
 int
 tapdisk_xenblkif_connect(domid_t domid, int devid, const grant_ref_t * grefs,
                          int order, evtchn_port_t port, bool persistent_grant,
+                         unsigned int indirect_max_segments,
                          int proto, int poll_duration, int poll_idle_threshold,
                          const char *pool, td_vbd_t * vbd);
 

--- a/drivers/td-blkif.h
+++ b/drivers/td-blkif.h
@@ -222,8 +222,9 @@ struct td_xenblkif {
  */
 int
 tapdisk_xenblkif_connect(domid_t domid, int devid, const grant_ref_t * grefs,
-        int order, evtchn_port_t port, int proto, int poll_duration,
-        int poll_idle_threshold, const char *pool, td_vbd_t * vbd);
+                         int order, evtchn_port_t port, bool persistent_grant,
+                         int proto, int poll_duration, int poll_idle_threshold,
+                         const char *pool, td_vbd_t * vbd);
 
 /**
  * Disconnects the tapdisk from the shared ring.

--- a/include/tap-ctl.h
+++ b/include/tap-ctl.h
@@ -186,8 +186,10 @@ int tap_ctl_disconnect_xenblkif(const pid_t pid, const domid_t domid,
  * @param minor
  *
  */
-int tap_ctl_info(pid_t pid, unsigned long long *sectors, unsigned int
-		*sector_size, unsigned int *info, const int minor);
+int tap_ctl_info(pid_t pid, unsigned long long *sectors,
+		unsigned int *sector_size, unsigned int *info,
+		unsigned int *max_queues,
+		const int minor);
 
 /**
  * Parses a type:/path/to/file string, storing the type and path to the output

--- a/include/tap-ctl.h
+++ b/include/tap-ctl.h
@@ -183,12 +183,15 @@ int tap_ctl_disconnect_xenblkif(const pid_t pid, const domid_t domid,
  * @param sector_size output parameter that receives the size of the sector
  * @param info output parameter that receives the vdisk info flags VDISK_???,
  * defined in include/xen/interface/io/blkif.h
+ * @param discard output parameter that receives if discard is supported
+ * @param discard_granularity output parameter that receives the discard granularity
  * @param minor
  *
  */
 int tap_ctl_info(pid_t pid, unsigned long long *sectors,
 		unsigned int *sector_size, unsigned int *info,
 		unsigned int *max_queues,
+		bool *discard, unsigned int *discard_granularity,
 		const int minor);
 
 /**

--- a/include/tapdisk-common.h
+++ b/include/tapdisk-common.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026, Vates SAS
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _TAPDISK_COMMON_H_
+#define _TAPDISK_COMMON_H_
+
+#define BLKIF_MAX_QUEUES           1
+
+#define TAPDISK_MAX_VBD_THREADS    BLKIF_MAX_QUEUES
+
+#endif

--- a/include/tapdisk-message.h
+++ b/include/tapdisk-message.h
@@ -22,6 +22,7 @@
 #include <sys/types.h>
 
 #include "xen_blkif.h"
+#include "tapdisk-common.h"
 
 /*
  * TODO This is quite small since we don't allow path bigger than 256 chars. If
@@ -72,6 +73,7 @@ struct tapdisk_message_image {
 	uint64_t                         sectors;
 	uint32_t                         sector_size;
 	uint32_t                         info;
+	uint32_t                         max_queues;
 };
 
 struct tapdisk_message_string {
@@ -123,13 +125,22 @@ typedef struct tapdisk_message_blkif {
 	uint32_t devid;
 
 	/**
-	 * Grant references for the shared ring.
-	 * See order below to know the number of used refs in this array.
+	 * Number of queues
 	 */
-	uint32_t gref[MAX_RING_PAGES];
+	uint32_t nr_queues;
 
 	/**
-	 * Number of pages in the ring, expressed as a page order.
+	 * Grant references for the shared ring.
+	 */
+	grant_ref_t gref[BLKIF_MAX_QUEUES][MAX_RING_PAGES];
+
+	/**
+	 * The event channel port.
+	 */
+	uint32_t ports[BLKIF_MAX_QUEUES];
+
+	/**
+	 * Number of pages in rings, expressed as a page order.
 	 */
 	uint32_t order;
 
@@ -143,11 +154,6 @@ typedef struct tapdisk_message_blkif {
 	 * Page pool name? Can be empty (ie "")
 	 */
 	char pool_name[TAPDISK_MESSAGE_STRING_LENGTH];
-
-	/**
-	 * The event channel port.
-	 */
-	uint32_t port;
 
 	/**
 	 * Polling duration in microseconds. 0 means no polling.

--- a/include/tapdisk-message.h
+++ b/include/tapdisk-message.h
@@ -19,6 +19,7 @@
 #define _TAPDISK_MESSAGE_H_
 
 #include <inttypes.h>
+#include <stdbool.h>
 #include <sys/types.h>
 
 #include "xen_blkif.h"
@@ -74,6 +75,8 @@ struct tapdisk_message_image {
 	uint32_t                         sector_size;
 	uint32_t                         info;
 	uint32_t                         max_queues;
+	bool                             discard;
+	uint32_t                         discard_granularity;
 };
 
 struct tapdisk_message_string {

--- a/include/tapdisk-message.h
+++ b/include/tapdisk-message.h
@@ -172,6 +172,11 @@ typedef struct tapdisk_message_blkif {
 	 * Persistent grants feature enabled.
 	 */
 	bool persistent_grants;
+
+	/**
+	 * Maximum number of segments per page in indirect requests.
+	 */
+	uint32_t indirect_max_segments;
 } tapdisk_message_blkif_t;
 
 /**

--- a/include/tapdisk-message.h
+++ b/include/tapdisk-message.h
@@ -167,6 +167,11 @@ typedef struct tapdisk_message_blkif {
 	 * Idle CPU threshold above which polling is permitted.
 	 */
 	uint32_t poll_idle_threshold;
+
+	/**
+	 * Persistent grants feature enabled.
+	 */
+	bool persistent_grants;
 } tapdisk_message_blkif_t;
 
 /**

--- a/tapback/backend.c
+++ b/tapback/backend.c
@@ -328,6 +328,7 @@ physical_device_path_changed(vbd_t *device) {
 	if ((err = tap_ctl_info(device->tap->pid, &device->sectors,
 				&device->sector_size, &device->info,
 				&device->max_queues,
+				&device->discard, &device->discard_granularity,
 				device->minor))) {
 		WARN(device, "error retrieving disk characteristics: %s\n",
 		     strerror(-err));
@@ -366,6 +367,8 @@ out:
 		free(device->tap);
 		device->tap = NULL;
 		device->sector_size = device->sectors = device->info = 0;
+		device->discard = false;
+		device->discard_granularity = 0;
 	}
 	free(s);
 done:
@@ -487,6 +490,7 @@ physical_device_changed(vbd_t *device) {
     if ((err = tap_ctl_info(device->tap->pid, &device->sectors,
                     &device->sector_size, &info,
                     &device->max_queues,
+                    &device->discard, &device->discard_granularity,
                     device->minor))) {
         WARN(device, "error retrieving disk characteristics: %s\n",
                 strerror(-err));
@@ -524,6 +528,8 @@ out:
         free(device->tap);
         device->tap = NULL;
         device->sector_size = device->sectors = device->info = 0;
+        device->discard = false;
+        device->discard_granularity = 0;
     }
     free(s);
     return err;

--- a/tapback/backend.c
+++ b/tapback/backend.c
@@ -326,8 +326,9 @@ physical_device_path_changed(vbd_t *device) {
 	 * get the VBD parameters from the tapdisk
 	 */
 	if ((err = tap_ctl_info(device->tap->pid, &device->sectors,
-					&device->sector_size, &device->info,
-					device->minor))) {
+				&device->sector_size, &device->info,
+				&device->max_queues,
+				device->minor))) {
 		WARN(device, "error retrieving disk characteristics: %s\n",
 		     strerror(-err));
 		goto out;
@@ -485,6 +486,7 @@ physical_device_changed(vbd_t *device) {
      */
     if ((err = tap_ctl_info(device->tap->pid, &device->sectors,
                     &device->sector_size, &info,
+                    &device->max_queues,
                     device->minor))) {
         WARN(device, "error retrieving disk characteristics: %s\n",
                 strerror(-err));

--- a/tapback/tapback.h
+++ b/tapback/tapback.h
@@ -198,6 +198,11 @@ typedef struct backend {
 	 * Tells whether we support write I/O barriers.
 	 */
 	bool barrier;
+
+	/**
+	 * Tells whether we support discard.
+	 */
+	bool discard;
 } backend_t;
 
 /**
@@ -283,6 +288,16 @@ typedef struct vbd {
      * Max number of queues supported by the driver
      */
     unsigned int max_queues;
+
+    /*
+     * Whether the backing driver supports discard
+     */
+    bool discard;
+
+    /**
+     * Discard granularity, supplied by the tapdisk, communicated to blkfront.
+     */
+    unsigned int discard_granularity;
 
     int major;
 	int minor;

--- a/tapback/tapback.h
+++ b/tapback/tapback.h
@@ -279,6 +279,11 @@ typedef struct vbd {
      */
     unsigned int info;
 
+    /**
+     * Max number of queues supported by the driver
+     */
+    unsigned int max_queues;
+
     int major;
 	int minor;
 


### PR DESCRIPTION
The idea to put things that could break ABI in a single merge, even if features are not implemented yet.
It mainly concerns messages exchanged between `tap-ctl` and `tapdisk`.