### PR TITLE
Fix unit tests with recent cmocka

### DIFF
--- a/mockatests/cbt/test-cbt-util-coalesce.c
+++ b/mockatests/cbt/test-cbt-util-coalesce.c
@@ -34,6 +34,7 @@
 #include <stdarg.h>
 #include <setjmp.h>
 #include <cmocka.h>
+#include <cmocka-compat.h>
 #include <errno.h>
 
 #include <cbt-util-priv.h>
@@ -102,7 +103,7 @@ void test_cbt_util_coalesce_no_child_file_failure(void **state)
 								sizeof(struct cbt_log_metadata), "r");
 
 	will_return(__wrap_fopen, parent_log);
-	expect_value(__wrap_fclose, fp, parent_log);
+	expect_ptr_value(__wrap_fclose, fp, parent_log);
 
 	will_return(__wrap_fopen, NULL);
 
@@ -123,7 +124,7 @@ void test_cbt_util_coalesce_parent_log_malloc_failure(void **state)
 	FILE *test_log = fmemopen((void*)log_meta, 1, "r");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	malloc_succeeds(false);
 
@@ -150,10 +151,10 @@ void test_cbt_util_coalesce_child_log_malloc_failure(void **state)
 								sizeof(struct cbt_log_metadata), "r");
 
 	will_return(__wrap_fopen, parent_log);
-	expect_value(__wrap_fclose, fp, parent_log);
+	expect_ptr_value(__wrap_fclose, fp, parent_log);
 
 	will_return(__wrap_fopen, child_log);
-	expect_value(__wrap_fclose, fp, child_log);
+	expect_ptr_value(__wrap_fclose, fp, child_log);
 
 	malloc_succeeds(true);
 	malloc_succeeds(false);
@@ -178,7 +179,7 @@ void test_cbt_util_coalesce_no_parent_meta_failure(void **state)
 	FILE *test_log = fmemopen((void*)log_meta, 1, "r");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	result = cbt_util_coalesce(6, args);
 	assert_int_equal(result, -EIO);
@@ -200,9 +201,9 @@ void test_cbt_util_coalesce_no_child_meta_failure(void **state)
 	FILE *child_log = fmemopen((void*)child_meta, 1, "r");
 
 	will_return(__wrap_fopen, parent_log);
-	expect_value(__wrap_fclose, fp, parent_log);
+	expect_ptr_value(__wrap_fclose, fp, parent_log);
 	will_return(__wrap_fopen, child_log);
-	expect_value(__wrap_fclose, fp, child_log);
+	expect_ptr_value(__wrap_fclose, fp, child_log);
 
 	result = cbt_util_coalesce(6, args);
 	assert_int_equal(result, -EIO);
@@ -232,9 +233,9 @@ void test_cbt_util_coalesce_larger_parent_bitmap_failure(void **state)
 								sizeof(struct cbt_log_metadata), "r");
 
 	will_return(__wrap_fopen, parent_log);
-	expect_value(__wrap_fclose, fp, parent_log);
+	expect_ptr_value(__wrap_fclose, fp, parent_log);
 	will_return(__wrap_fopen, child_log);
-	expect_value(__wrap_fclose, fp, child_log);
+	expect_ptr_value(__wrap_fclose, fp, child_log);
 
 	result = cbt_util_coalesce(6, args);
 	assert_int_equal(result, -EINVAL);
@@ -259,9 +260,9 @@ void test_cbt_util_coalesce_parent_bitmap_malloc_failure(void **state)
 	FILE *child_log = fmemopen((void*)log_meta, file_size, "r+");
 
 	will_return(__wrap_fopen, parent_log);
-	expect_value(__wrap_fclose, fp, parent_log);
+	expect_ptr_value(__wrap_fclose, fp, parent_log);
 	will_return(__wrap_fopen, child_log);
-	expect_value(__wrap_fclose, fp, child_log);
+	expect_ptr_value(__wrap_fclose, fp, child_log);
 
 	malloc_succeeds(true);
 	malloc_succeeds(true);
@@ -292,9 +293,9 @@ void test_cbt_util_coalesce_child_bitmap_malloc_failure(void **state)
 	FILE *child_log = fmemopen((void*)log_meta, file_size, "r+");
 
 	will_return(__wrap_fopen, parent_log);
-	expect_value(__wrap_fclose, fp, parent_log);
+	expect_ptr_value(__wrap_fclose, fp, parent_log);
 	will_return(__wrap_fopen, child_log);
-	expect_value(__wrap_fclose, fp, child_log);
+	expect_ptr_value(__wrap_fclose, fp, child_log);
 
 	malloc_succeeds(true);
 	malloc_succeeds(true);
@@ -326,9 +327,9 @@ void test_cbt_util_coalesce_parent_no_bitmap_data_failure(void **state)
 							sizeof(struct cbt_log_metadata), "r+");
 
 	will_return(__wrap_fopen, parent_log);
-	expect_value(__wrap_fclose, fp, parent_log);
+	expect_ptr_value(__wrap_fclose, fp, parent_log);
 	will_return(__wrap_fopen, child_log);
-	expect_value(__wrap_fclose, fp, child_log);
+	expect_ptr_value(__wrap_fclose, fp, child_log);
 
 	result = cbt_util_coalesce(6, args);
 	assert_int_equal(result, -EIO);
@@ -360,9 +361,9 @@ void test_cbt_util_coalesce_child_no_bitmap_data_failure(void **state)
 							sizeof(struct cbt_log_metadata), "r+");
 
 	will_return(__wrap_fopen, parent_log);
-	expect_value(__wrap_fclose, fp, parent_log);
+	expect_ptr_value(__wrap_fclose, fp, parent_log);
 	will_return(__wrap_fopen, child_log);
-	expect_value(__wrap_fclose, fp, child_log);
+	expect_ptr_value(__wrap_fclose, fp, child_log);
 
 	result = cbt_util_coalesce(6, args);
 	assert_int_equal(result, -EIO);
@@ -402,9 +403,9 @@ void test_cbt_util_coalesce_success(void **state)
 	FILE *child_log = fmemopen((void*)child_data, file_size, "r");
 
 	will_return(__wrap_fopen, parent_log);
-	expect_value(__wrap_fclose, fp, parent_log);
+	expect_ptr_value(__wrap_fclose, fp, parent_log);
 	will_return(__wrap_fopen, child_log);
-	expect_value(__wrap_fclose, fp, child_log);
+	expect_ptr_value(__wrap_fclose, fp, child_log);
 	enable_mock_fwrite();
 	output = setup_fwrite_mock(bmsize);
 
@@ -451,9 +452,9 @@ void test_cbt_util_coalesce_set_file_pointer_failure(void **state)
 	FILE *child_log = fmemopen((void*)child_data, file_size, "r+");
 
 	will_return(__wrap_fopen, parent_log);
-	expect_value(__wrap_fclose, fp, parent_log);
+	expect_ptr_value(__wrap_fclose, fp, parent_log);
 	will_return(__wrap_fopen, child_log);
-	expect_value(__wrap_fclose, fp, child_log);
+	expect_ptr_value(__wrap_fclose, fp, child_log);
 
 	fail_fseek(EIO);
 
@@ -494,9 +495,9 @@ void test_cbt_util_coalesce_write_bitmap_failure(void **state)
 	FILE *child_log = fmemopen((void*)child_data, file_size, "r");
 
 	will_return(__wrap_fopen, parent_log);
-	expect_value(__wrap_fclose, fp, parent_log);
+	expect_ptr_value(__wrap_fclose, fp, parent_log);
 	will_return(__wrap_fopen, child_log);
-	expect_value(__wrap_fclose, fp, child_log);
+	expect_ptr_value(__wrap_fclose, fp, child_log);
 
 	result = cbt_util_coalesce(6, args);
 	assert_int_equal(result, -EIO);

--- a/mockatests/cbt/test-cbt-util-commands.c
+++ b/mockatests/cbt/test-cbt-util-commands.c
@@ -32,6 +32,7 @@
 #include <stdarg.h>
 #include <setjmp.h>
 #include <cmocka.h>
+#include <cmocka-compat.h>
 
 #include <cbt-util-priv.h>
 #include <wrappers.h>
@@ -122,7 +123,7 @@ test_help_success(void ** state)
 
 	help();
 
-	assert_in_range(output->offset, 10, 1024);
+	assert_int_in_range(output->offset, 10, 1024);
 
 	free_printf_data(output);
 }

--- a/mockatests/cbt/test-cbt-util-create.c
+++ b/mockatests/cbt/test-cbt-util-create.c
@@ -32,6 +32,7 @@
 #include <stdarg.h>
 #include <setjmp.h>
 #include <cmocka.h>
+#include <cmocka-compat.h>
 #include <errno.h>
 
 #include <cbt-util-priv.h>
@@ -51,7 +52,7 @@ void test_cbt_util_create_success(void **state)
 	FILE *test_log = fmemopen(log_meta, file_size, "w+");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	result = cbt_util_create(5, args);
 
@@ -86,7 +87,7 @@ void test_cbt_util_create_metadata_write_failure(void **state)
 	setbuf(test_log, NULL);
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	result = cbt_util_create(5, args);
 
@@ -107,7 +108,7 @@ void test_cbt_util_create_bitmap_write_failure(void **state)
 	setbuf(test_log, NULL);
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	result = cbt_util_create(5, args);
 

--- a/mockatests/cbt/test-cbt-util-get.c
+++ b/mockatests/cbt/test-cbt-util-get.c
@@ -34,6 +34,7 @@
 #include <stdarg.h>
 #include <setjmp.h>
 #include <cmocka.h>
+#include <cmocka-compat.h>
 #include <errno.h>
 #include <uuid/uuid.h>
 
@@ -54,7 +55,7 @@ void test_cbt_util_get_flag(void **state)
 	FILE *test_log = fmemopen((void*)log_meta, sizeof(struct cbt_log_metadata), "r");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	output = setup_vprintf_mock(1024);
 
@@ -83,7 +84,7 @@ void test_cbt_util_get_parent(void **state)
 	FILE *test_log = fmemopen((void*)log_meta, sizeof(struct cbt_log_metadata), "r");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	output = setup_vprintf_mock(1024);
 
@@ -115,7 +116,7 @@ void test_cbt_util_get_child(void **state)
 	FILE *test_log = fmemopen((void*)log_meta, sizeof(struct cbt_log_metadata), "r");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	output = setup_vprintf_mock(1024);
 
@@ -143,7 +144,7 @@ void test_cbt_util_get_size(void **state)
 	FILE *test_log = fmemopen((void*)log_meta, sizeof(struct cbt_log_metadata), "r");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	output = setup_vprintf_mock(1024);
 
@@ -175,7 +176,7 @@ void test_cbt_util_get_bitmap(void **state)
 	FILE *test_log = fmemopen((void*)log_meta, file_size, "r");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 	enable_mock_fwrite();
 	output = setup_fwrite_mock(bmsize);
 
@@ -201,7 +202,7 @@ void test_cbt_util_get_bitmap_nodata_failure(void **state)
 	FILE *test_log = fmemopen((void*)log_meta, sizeof(struct cbt_log_metadata), "r");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	result = cbt_util_get(5, args);
 	assert_int_equal(result, -EIO);
@@ -222,7 +223,7 @@ void test_cbt_util_get_bitmap_malloc_failure(void **state)
 	FILE *test_log = fmemopen((void*)log_meta, file_size, "r");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	malloc_succeeds(true);
 	malloc_succeeds(false);
@@ -268,7 +269,7 @@ void test_cbt_util_get_nodata_failure(void **state)
 	FILE *test_log = fmemopen((void*)log_meta, 1, "r");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	result = cbt_util_get(4, args);
 

--- a/mockatests/cbt/test-cbt-util-set.c
+++ b/mockatests/cbt/test-cbt-util-set.c
@@ -35,6 +35,7 @@
 #include <stdarg.h>
 #include <setjmp.h>
 #include <cmocka.h>
+#include <cmocka-compat.h>
 #include <errno.h>
 #include <uuid/uuid.h>
 #include <inttypes.h>
@@ -63,7 +64,7 @@ test_cbt_util_set_parent(void **state)
 	FILE *test_log = fmemopen((void*)log_meta, sizeof(struct cbt_log_metadata), "r+");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	result = cbt_util_set(5, args);
 	assert_int_equal(result, 0);
@@ -92,7 +93,7 @@ test_cbt_util_set_child(void **state)
 	FILE *test_log = fmemopen((void*)log_meta, sizeof(struct cbt_log_metadata), "r+");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	result = cbt_util_set(5, args);
 	assert_int_equal(result, 0);
@@ -118,7 +119,7 @@ test_cbt_util_set_flag(void **state)
 	FILE *test_log = fmemopen((void*)log_meta, sizeof(struct cbt_log_metadata), "r+");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	result = cbt_util_set(5, args);
 	assert_int_equal(result, 0);
@@ -151,7 +152,7 @@ test_cbt_util_set_size(void **state)
 	FILE *test_log = fmemopen((void*)log_meta, file_size, "r+");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	result = cbt_util_set(5, args);
 	assert_int_equal(result, 0);
@@ -181,7 +182,7 @@ test_cbt_util_set_size_smaller_file_failure(void **state)
 	FILE *test_log = fmemopen((void*)log_meta, sizeof(struct cbt_log_metadata), "r+");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	result = cbt_util_set(5, args);
 	assert_int_equal(result, -EINVAL);
@@ -209,7 +210,7 @@ test_cbt_util_set_size_malloc_failure(void **state)
 	FILE *test_log = fmemopen((void*)log_meta, file_size, "r+");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);	
+	expect_ptr_value(__wrap_fclose, fp, test_log);	
 		
 	malloc_succeeds(true);
 	malloc_succeeds(false);
@@ -234,7 +235,7 @@ test_cbt_util_set_size_no_bitmap_failure(void **state)
 	FILE *test_log = fmemopen((void*)log_meta, sizeof(struct cbt_log_metadata), "r+");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	result = cbt_util_set(5, args);
 	assert_int_equal(result, -EIO);
@@ -263,7 +264,7 @@ test_cbt_util_set_size_write_failure(void **state)
 	FILE *test_log = fmemopen((void*)log_meta, file_size, "r");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	result = cbt_util_set(5, args);
 	assert_int_equal(result, -EIO);
@@ -292,7 +293,7 @@ test_cbt_util_set_size_reset_file_pointer_failure(void **state)
 	FILE *test_log = fmemopen((void*)log_meta, file_size, "r+");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	fail_fseek(EIO);
 
@@ -366,7 +367,7 @@ test_cbt_util_set_no_data_failure(void **state)
 	FILE *test_log = fmemopen((void*)log_meta, 1, "r+");
 
 	will_return(__wrap_fopen, test_log);
-	expect_value(__wrap_fclose, fp, test_log);
+	expect_ptr_value(__wrap_fclose, fp, test_log);
 
 	result = cbt_util_set(5, args);
 	assert_int_equal(result, -EIO);

--- a/mockatests/control/Makefile.am
+++ b/mockatests/control/Makefile.am
@@ -16,7 +16,7 @@ test_control_LDFLAGS += -static-libtool-libs
 # Would be good to use the cmocka malloc wraps but looks like maybe strdup doesn't call malloc
 #test_control_LDFLAGS += -Wl,--wrap=malloc,--wrap=free
 test_control_LDFLAGS += -Wl,--wrap=socket,--wrap=connect,--wrap=read,--wrap=select,--wrap=write,--wrap=fdopen
-test_control_LDFLAGS += -Wl,--wrap=open,--wrap=ioctl,--wrap=close,--wrap=access,--wrap=mkdir,--wrap=flock,--wrap=unlink,--wrap=__xmknod
+test_control_LDFLAGS += -Wl,--wrap=open,--wrap=ioctl,--wrap=close,--wrap=access,--wrap=mkdir,--wrap=flock,--wrap=unlink,--wrap=mknod,--wrap=__xmknod
 #test_control_LDFLAGS += -Wl,--wrap=execl,--wrap=waitpid
 test_control_LDFLAGS += -Wl,--wrap=glob,--wrap=globfree
 test_control_LDFLAGS += -Wl,--wrap=fopen,--wrap=fclose,--wrap=fseek,--wrap=fwrite

--- a/mockatests/control/control-wrappers.c
+++ b/mockatests/control/control-wrappers.c
@@ -248,10 +248,24 @@ __wrap_flock(int fd, int operation)
 	return result;
 }
 
+/*
+ * Prior to glibc 2.33, mknod(3) was an inline wrapper in <sys/stat.h>
+ * that forwarded to the exported __xmknod() symbol.
+ * Since glibc 2.33, mknod() is exported directly so we have to wrap
+ * mknod() instead.
+ *
+ * Compiler flags (-fno-inline, -Og) and glibc version both influence
+ * which symbol the call site actually references, so we define both
+ * wrappers unconditionally.
+ */
 int
-__wrap___xmknod(int ver, const char *pathname, mode_t mode, dev_t * dev)
+__wrap_mknod(const char *pathname, mode_t mode, dev_t dev)
 {
 	int result;
+
+	(void)mode;
+	(void)dev;
+
 	check_expected_ptr(pathname);
 	result = mock();
 	if (result != 0)
@@ -260,6 +274,16 @@ __wrap___xmknod(int ver, const char *pathname, mode_t mode, dev_t * dev)
 		result = -1;
 	}
 	return result;
+}
+
+int
+__wrap___xmknod(int ver, const char *pathname, mode_t mode, dev_t *dev)
+{
+	(void)ver;
+	(void)mode;
+	(void)dev;
+
+	return __wrap_mknod(pathname, mode, (dev_t)(dev ? *dev : 0));
 }
 
 int

--- a/mockatests/control/control-wrappers.c
+++ b/mockatests/control/control-wrappers.c
@@ -38,6 +38,8 @@
 #include <errno.h>
 #include <sys/socket.h>
 
+#include <cmocka-compat.h>
+
 #include "control-wrappers.h"
 
 static int enable_mocks = 0;
@@ -66,8 +68,8 @@ __wrap_ioctl(int fd, int request, ...)
 {
 	int result;
 
-	check_expected(fd);
-	check_expected(request);
+	check_expected_int(fd);
+	check_expected_int(request);
 
 	result = (int)mock();
 
@@ -88,7 +90,7 @@ __wrap_open(const char *pathname, int flags)
 	int result;
 
 	if (enable_mocks) {
-		check_expected(pathname);
+		check_expected_ptr(pathname);
 		result = mock();
 		if (result == -1)
 			errno = ENOENT;
@@ -106,7 +108,7 @@ __wrap_close(int fd)
 {
 	int result;
 
-	check_expected(fd);
+	check_expected_int(fd);
 	result = mock();
 	if (result != 0)
 	{
@@ -125,7 +127,7 @@ __wrap_access(const char *pathname, int mode)
 	int result;
 
 	if (enable_mocks) {
-		check_expected(pathname);
+		check_expected_ptr(pathname);
 
 		result = mock();
 		if (result != 0) {
@@ -143,7 +145,7 @@ __wrap_read(int fd, void *buf, size_t count)
 	int result = -1;
 	struct mock_read_params *params;
 
-	check_expected(fd);
+	check_expected_int(fd);
 	params = (struct mock_read_params *)mock();
 
 	if (params->result > 0) {
@@ -171,8 +173,8 @@ __wrap_write(int fd, const void *buf, size_t count)
 {
 	int result;
 
-	check_expected(fd);
-	check_expected(buf);
+	check_expected_int(fd);
+	check_expected_ptr(buf);
 	result = mock();
 
 	if (result > (int)count)
@@ -188,8 +190,8 @@ int
 __wrap_connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 {
 	int result;
-	check_expected(sockfd);
-	check_expected(addr);
+	check_expected_int(sockfd);
+	check_expected_ptr(addr);
 	result = mock();
 	if (result) {
 		errno = result;
@@ -203,7 +205,7 @@ __wrap_select(int nfds, fd_set *readfds, fd_set *writefds,
 	      fd_set *exceptfds, struct timeval *timeout)
 {
 	struct mock_select_params *params;
-	check_expected(timeout);
+	check_expected_ptr(timeout);
 	params = (struct mock_select_params *)mock();
 	if (readfds)
 		memcpy(readfds, &params->readfds, sizeof(fd_set));
@@ -222,7 +224,7 @@ __wrap_mkdir(const char *pathname, mode_t mode)
 {
 	int result;
 	if (enable_mocks) {
-		check_expected(pathname);
+		check_expected_ptr(pathname);
 		result = mock();
 		if (result != 0){
 			errno = result;
@@ -237,7 +239,7 @@ int
 __wrap_flock(int fd, int operation)
 {
 	int result;
-	check_expected(fd);
+	check_expected_int(fd);
 	result = mock();
 	if (result != 0) {
 		errno = result;
@@ -250,7 +252,7 @@ int
 __wrap___xmknod(int ver, const char *pathname, mode_t mode, dev_t * dev)
 {
 	int result;
-	check_expected(pathname);
+	check_expected_ptr(pathname);
 	result = mock();
 	if (result != 0)
 	{
@@ -264,7 +266,7 @@ int
 __wrap_unlink(const char *pathname)
 {
 	int result;
-	check_expected(pathname);
+	check_expected_ptr(pathname);
 	result = mock();
 	if (result != 0)
 	{
@@ -279,9 +281,9 @@ __wrap_socket(int domain, int type, int protocol)
 {
 	int result;
 
-	check_expected(domain);
-	check_expected(type);
-	check_expected(protocol);
+	check_expected_int(domain);
+	check_expected_int(type);
+	check_expected_int(protocol);
 
 	result = mock();
 
@@ -297,7 +299,7 @@ __wrap_glob(const char *pattern, int flags,
 	    int (*errfunc) (const char *epath, int eerrno),
 	    glob_t *pglob)
 {
-	check_expected(pattern);
+	check_expected_ptr(pattern);
 	int result = mock();
 	if (result == 0)
 	{

--- a/mockatests/control/test-tap-ctl-allocate.c
+++ b/mockatests/control/test-tap-ctl-allocate.c
@@ -33,6 +33,7 @@
 #include <string.h>
 #include <setjmp.h>
 #include <cmocka.h>
+#include <cmocka-compat.h>
 #include <errno.h>
 
 #include <wrappers.h>
@@ -136,13 +137,13 @@ void test_tap_ctl_allocate_no_device_info(void **state)
 	/* Check Environment */
 	will_return(__wrap_fopen, proc_misc);
 	will_return(__wrap_flock, 0);
-	expect_value(__wrap_flock, fd, fileno(proc_misc));
+	expect_int_value(__wrap_flock, fd, fileno(proc_misc));
 	will_return(__wrap_access, ENOENT);
 	expect_string(__wrap_access, pathname, "/dev/xen/blktap-2/control");
 	/* Close check environment */
 	will_return(__wrap_flock, 0);
-	expect_value(__wrap_flock, fd, fileno(proc_misc));
-	expect_value(__wrap_fclose, fp, proc_misc);
+	expect_int_value(__wrap_flock, fd, fileno(proc_misc));
+	expect_ptr_value(__wrap_fclose, fp, proc_misc);
 
 	result = tap_ctl_allocate(&minor, &devname);
 
@@ -165,7 +166,7 @@ void test_tap_ctl_allocate_make_device_fail(void **state)
 	/* Check Environment */
 	will_return(__wrap_fopen, proc_misc);
 	will_return(__wrap_flock, 0);
-	expect_value(__wrap_flock, fd, fileno(proc_misc));
+	expect_int_value(__wrap_flock, fd, fileno(proc_misc));
 	will_return(__wrap_access, ENOENT);
 	expect_string(__wrap_access, pathname, "/dev/xen/blktap-2/control");
 	/* Make Device/Prepare Directory*/
@@ -177,8 +178,8 @@ void test_tap_ctl_allocate_make_device_fail(void **state)
 	expect_string(__wrap___xmknod, pathname, "/dev/xen/blktap-2/control");
 	/* Close check environment */
 	will_return(__wrap_flock, 0);
-	expect_value(__wrap_flock, fd, fileno(proc_misc));
-	expect_value(__wrap_fclose, fp, proc_misc);
+	expect_int_value(__wrap_flock, fd, fileno(proc_misc));
+	expect_ptr_value(__wrap_fclose, fp, proc_misc);
 
 	result = tap_ctl_allocate(&minor, &devname);
 
@@ -202,7 +203,7 @@ void test_tap_ctl_allocate_ring_create_fail(void **state)
 	/* Check Environment */
 	will_return(__wrap_fopen, proc_misc);
 	will_return(__wrap_flock, 0);
-	expect_value(__wrap_flock, fd, fileno(proc_misc));
+	expect_int_value(__wrap_flock, fd, fileno(proc_misc));
 	will_return(__wrap_access, ENOENT);
 	expect_string(__wrap_access, pathname, "/dev/xen/blktap-2/control");
 	/* Make Device/Prepare Directory*/
@@ -214,16 +215,16 @@ void test_tap_ctl_allocate_ring_create_fail(void **state)
 	expect_string(__wrap___xmknod, pathname, "/dev/xen/blktap-2/control");
 	/* Close check environment */
 	will_return(__wrap_flock, 0);
-	expect_value(__wrap_flock, fd, fileno(proc_misc));
-	expect_value(__wrap_fclose, fp, proc_misc);
+	expect_int_value(__wrap_flock, fd, fileno(proc_misc));
+	expect_ptr_value(__wrap_fclose, fp, proc_misc);
 	/* allocate device */
 	will_return(__wrap_open, dev_fd);
 	expect_string(__wrap_open, pathname, "/dev/xen/blktap-2/control");
 	will_return(__wrap_ioctl, 0);
-	expect_value(__wrap_ioctl, fd, dev_fd);
-	expect_value(__wrap_ioctl, request, BLKTAP2_IOCTL_ALLOC_TAP);
+	expect_int_value(__wrap_ioctl, fd, dev_fd);
+	expect_int_value(__wrap_ioctl, request, BLKTAP2_IOCTL_ALLOC_TAP);
 	will_return(__wrap_close, 0);
-	expect_value(__wrap_close, fd, dev_fd);
+	expect_int_value(__wrap_close, fd, dev_fd);
 	/* Make Device - ring */
 	will_return(__wrap_access, ENOENT);
 	expect_string(__wrap_access, pathname, "/dev/xen/blktap-2");
@@ -241,10 +242,10 @@ void test_tap_ctl_allocate_ring_create_fail(void **state)
 	will_return(__wrap_open, dev_fd);
 	expect_string(__wrap_open, pathname, "/dev/xen/blktap-2/control");
 	will_return(__wrap_ioctl, 0);
-	expect_value(__wrap_ioctl, fd, dev_fd);
-	expect_value(__wrap_ioctl, request, BLKTAP2_IOCTL_FREE_TAP);
+	expect_int_value(__wrap_ioctl, fd, dev_fd);
+	expect_int_value(__wrap_ioctl, request, BLKTAP2_IOCTL_FREE_TAP);
 	will_return(__wrap_close, 0);
-	expect_value(__wrap_close, fd, dev_fd);
+	expect_int_value(__wrap_close, fd, dev_fd);
 
 	result = tap_ctl_allocate(&minor, &devname);
 
@@ -268,7 +269,7 @@ void test_tap_ctl_allocate_io_device_fail(void **state)
 	/* Check Environment */
 	will_return(__wrap_fopen, proc_misc);
 	will_return(__wrap_flock, 0);
-	expect_value(__wrap_flock, fd, fileno(proc_misc));
+	expect_int_value(__wrap_flock, fd, fileno(proc_misc));
 	will_return(__wrap_access, ENOENT);
 	expect_string(__wrap_access, pathname, "/dev/xen/blktap-2/control");
 	/* Make Device/Prepare Directory*/
@@ -280,16 +281,16 @@ void test_tap_ctl_allocate_io_device_fail(void **state)
 	expect_string(__wrap___xmknod, pathname, "/dev/xen/blktap-2/control");
 	/* Close check environment */
 	will_return(__wrap_flock, 0);
-	expect_value(__wrap_flock, fd, fileno(proc_misc));
-	expect_value(__wrap_fclose, fp, proc_misc);
+	expect_int_value(__wrap_flock, fd, fileno(proc_misc));
+	expect_ptr_value(__wrap_fclose, fp, proc_misc);
 	/* allocate device */
 	will_return(__wrap_open, dev_fd);
 	expect_string(__wrap_open, pathname, "/dev/xen/blktap-2/control");
 	will_return(__wrap_ioctl, 0);
-	expect_value(__wrap_ioctl, fd, dev_fd);
-	expect_value(__wrap_ioctl, request, BLKTAP2_IOCTL_ALLOC_TAP);
+	expect_int_value(__wrap_ioctl, fd, dev_fd);
+	expect_int_value(__wrap_ioctl, request, BLKTAP2_IOCTL_ALLOC_TAP);
 	will_return(__wrap_close, 0);
-	expect_value(__wrap_close, fd, dev_fd);
+	expect_int_value(__wrap_close, fd, dev_fd);
 	/* Make Device - ring */
 	will_return(__wrap_access, ENOENT);
 	expect_string(__wrap_access, pathname, "/dev/xen/blktap-2");
@@ -322,10 +323,10 @@ void test_tap_ctl_allocate_io_device_fail(void **state)
 	will_return(__wrap_open, dev_fd);
 	expect_string(__wrap_open, pathname, "/dev/xen/blktap-2/control");
 	will_return(__wrap_ioctl, 0);
-	expect_value(__wrap_ioctl, fd, dev_fd);
-	expect_value(__wrap_ioctl, request, BLKTAP2_IOCTL_FREE_TAP);
+	expect_int_value(__wrap_ioctl, fd, dev_fd);
+	expect_int_value(__wrap_ioctl, request, BLKTAP2_IOCTL_FREE_TAP);
 	will_return(__wrap_close, 0);
-	expect_value(__wrap_close, fd, dev_fd);
+	expect_int_value(__wrap_close, fd, dev_fd);
 
 	result = tap_ctl_allocate(&minor, &devname);
 
@@ -349,7 +350,7 @@ void test_tap_ctl_allocate_success(void **state)
 	/* Check Environment */
 	will_return(__wrap_fopen, proc_misc);
 	will_return(__wrap_flock, 0);
-	expect_value(__wrap_flock, fd, fileno(proc_misc));
+	expect_int_value(__wrap_flock, fd, fileno(proc_misc));
 	will_return(__wrap_access, ENOENT);
 	expect_string(__wrap_access, pathname, "/dev/xen/blktap-2/control");
 	/* Make Device/Prepare Directory*/
@@ -361,16 +362,16 @@ void test_tap_ctl_allocate_success(void **state)
 	expect_string(__wrap___xmknod, pathname, "/dev/xen/blktap-2/control");
 	/* Close check environment */
 	will_return(__wrap_flock, 0);
-	expect_value(__wrap_flock, fd, fileno(proc_misc));
-	expect_value(__wrap_fclose, fp, proc_misc);
+	expect_int_value(__wrap_flock, fd, fileno(proc_misc));
+	expect_ptr_value(__wrap_fclose, fp, proc_misc);
 	/* allocate device */
 	will_return(__wrap_open, dev_fd);
 	expect_string(__wrap_open, pathname, "/dev/xen/blktap-2/control");
 	will_return(__wrap_ioctl, 0);
-	expect_value(__wrap_ioctl, fd, dev_fd);
-	expect_value(__wrap_ioctl, request, BLKTAP2_IOCTL_ALLOC_TAP);
+	expect_int_value(__wrap_ioctl, fd, dev_fd);
+	expect_int_value(__wrap_ioctl, request, BLKTAP2_IOCTL_ALLOC_TAP);
 	will_return(__wrap_close, 0);
-	expect_value(__wrap_close, fd, dev_fd);
+	expect_int_value(__wrap_close, fd, dev_fd);
 	/* Make Device - ring */
 	will_return(__wrap_access, ENOENT);
 	expect_string(__wrap_access, pathname, "/dev/xen/blktap-2");

--- a/mockatests/control/test-tap-ctl-allocate.c
+++ b/mockatests/control/test-tap-ctl-allocate.c
@@ -174,8 +174,8 @@ void test_tap_ctl_allocate_make_device_fail(void **state)
 	expect_string(__wrap_access, pathname, "/dev/xen/blktap-2");
 	will_return(__wrap_unlink, 0);
 	expect_string(__wrap_unlink, pathname, "/dev/xen/blktap-2/control");
-	will_return(__wrap___xmknod, EPERM);
-	expect_string(__wrap___xmknod, pathname, "/dev/xen/blktap-2/control");
+	will_return(__wrap_mknod, EPERM);
+	expect_string(__wrap_mknod, pathname, "/dev/xen/blktap-2/control");
 	/* Close check environment */
 	will_return(__wrap_flock, 0);
 	expect_int_value(__wrap_flock, fd, fileno(proc_misc));
@@ -211,8 +211,8 @@ void test_tap_ctl_allocate_ring_create_fail(void **state)
 	expect_string(__wrap_access, pathname, "/dev/xen/blktap-2");
 	will_return(__wrap_unlink, 0);
 	expect_string(__wrap_unlink, pathname, "/dev/xen/blktap-2/control");
-	will_return(__wrap___xmknod, 0);
-	expect_string(__wrap___xmknod, pathname, "/dev/xen/blktap-2/control");
+	will_return(__wrap_mknod, 0);
+	expect_string(__wrap_mknod, pathname, "/dev/xen/blktap-2/control");
 	/* Close check environment */
 	will_return(__wrap_flock, 0);
 	expect_int_value(__wrap_flock, fd, fileno(proc_misc));
@@ -236,8 +236,8 @@ void test_tap_ctl_allocate_ring_create_fail(void **state)
 	expect_string(__wrap_mkdir, pathname, "/dev/xen/blktap-2");
 	will_return(__wrap_unlink, 0);
 	expect_any(__wrap_unlink, pathname);
-	will_return(__wrap___xmknod, EPERM);
-	expect_any(__wrap___xmknod, pathname);
+	will_return(__wrap_mknod, EPERM);
+	expect_any(__wrap_mknod, pathname);
 	/* tap-ctl-free */
 	will_return(__wrap_open, dev_fd);
 	expect_string(__wrap_open, pathname, "/dev/xen/blktap-2/control");
@@ -277,8 +277,8 @@ void test_tap_ctl_allocate_io_device_fail(void **state)
 	expect_string(__wrap_access, pathname, "/dev/xen/blktap-2");
 	will_return(__wrap_unlink, 0);
 	expect_string(__wrap_unlink, pathname, "/dev/xen/blktap-2/control");
-	will_return(__wrap___xmknod, 0);
-	expect_string(__wrap___xmknod, pathname, "/dev/xen/blktap-2/control");
+	will_return(__wrap_mknod, 0);
+	expect_string(__wrap_mknod, pathname, "/dev/xen/blktap-2/control");
 	/* Close check environment */
 	will_return(__wrap_flock, 0);
 	expect_int_value(__wrap_flock, fd, fileno(proc_misc));
@@ -302,8 +302,8 @@ void test_tap_ctl_allocate_io_device_fail(void **state)
 	expect_string(__wrap_mkdir, pathname, "/dev/xen/blktap-2");
 	will_return(__wrap_unlink, 0);
 	expect_any(__wrap_unlink, pathname);
-	will_return(__wrap___xmknod, 0);
-	expect_any(__wrap___xmknod, pathname);
+	will_return(__wrap_mknod, 0);
+	expect_any(__wrap_mknod, pathname);
 
 	/* Make Device - io device */
 	will_return(__wrap_access, ENOENT);
@@ -316,8 +316,8 @@ void test_tap_ctl_allocate_io_device_fail(void **state)
 	expect_string(__wrap_mkdir, pathname, "/dev/xen/blktap-2");
 	will_return(__wrap_unlink, 0);
 	expect_any(__wrap_unlink, pathname);
-	will_return(__wrap___xmknod, EPERM);
-	expect_any(__wrap___xmknod, pathname);
+	will_return(__wrap_mknod, EPERM);
+	expect_any(__wrap_mknod, pathname);
 
 	/* tap-ctl-free */
 	will_return(__wrap_open, dev_fd);
@@ -358,8 +358,8 @@ void test_tap_ctl_allocate_success(void **state)
 	expect_string(__wrap_access, pathname, "/dev/xen/blktap-2");
 	will_return(__wrap_unlink, 0);
 	expect_string(__wrap_unlink, pathname, "/dev/xen/blktap-2/control");
-	will_return(__wrap___xmknod, 0);
-	expect_string(__wrap___xmknod, pathname, "/dev/xen/blktap-2/control");
+	will_return(__wrap_mknod, 0);
+	expect_string(__wrap_mknod, pathname, "/dev/xen/blktap-2/control");
 	/* Close check environment */
 	will_return(__wrap_flock, 0);
 	expect_int_value(__wrap_flock, fd, fileno(proc_misc));
@@ -383,8 +383,8 @@ void test_tap_ctl_allocate_success(void **state)
 	expect_string(__wrap_mkdir, pathname, "/dev/xen/blktap-2");
 	will_return(__wrap_unlink, 0);
 	expect_any(__wrap_unlink, pathname);
-	will_return(__wrap___xmknod, 0);
-	expect_any(__wrap___xmknod, pathname);
+	will_return(__wrap_mknod, 0);
+	expect_any(__wrap_mknod, pathname);
 
 	/* Make Device - io device */
 	will_return(__wrap_access, ENOENT);
@@ -397,8 +397,8 @@ void test_tap_ctl_allocate_success(void **state)
 	expect_string(__wrap_mkdir, pathname, "/dev/xen/blktap-2");
 	will_return(__wrap_unlink, 0);
 	expect_any(__wrap_unlink, pathname);
-	will_return(__wrap___xmknod, 0);
-	expect_any(__wrap___xmknod, pathname);
+	will_return(__wrap_mknod, 0);
+	expect_any(__wrap_mknod, pathname);
 
 
 	result = tap_ctl_allocate(&minor, &devname);

--- a/mockatests/control/test-tap-ctl-close.c
+++ b/mockatests/control/test-tap-ctl-close.c
@@ -33,6 +33,7 @@
 #include <string.h>
 #include <setjmp.h>
 #include <cmocka.h>
+#include <cmocka-compat.h>
 #include <errno.h>
 
 #include <string.h>
@@ -71,29 +72,29 @@ void test_tap_ctl_close_success(void **state)
 	saddr.sun_family = AF_UNIX;
 	strcpy(saddr.sun_path, expected_sock_name);
 
-	expect_value(__wrap_socket, domain, AF_UNIX);
-	expect_value(__wrap_socket, type, SOCK_STREAM);
+	expect_int_value(__wrap_socket, domain, AF_UNIX);
+	expect_int_value(__wrap_socket, type, SOCK_STREAM);
 	expect_any(__wrap_socket, protocol);
 	will_return(__wrap_socket, ipc_socket);
 
-	expect_value(__wrap_connect, sockfd, ipc_socket);
+	expect_int_value(__wrap_connect, sockfd, ipc_socket);
 	expect_memory(__wrap_connect, addr, &saddr, sizeof(saddr));
 	will_return(__wrap_connect, 0);
 
 	write_select_params.result = 1;
 	FD_SET(ipc_socket, &write_select_params.writefds);
-	expect_value(__wrap_select, timeout, NULL);
+	expect_ptr_value(__wrap_select, timeout, NULL);
 	will_return(__wrap_select, &write_select_params);
 
 	write_message.type = TAPDISK_MESSAGE_CLOSE;
 	write_message.cookie = test_minor;
-	expect_value(__wrap_write, fd, ipc_socket);
+	expect_int_value(__wrap_write, fd, ipc_socket);
 	expect_memory(__wrap_write, buf, &write_message, sizeof(write_message));
 	will_return(__wrap_write, 1024);
 
 	read_select_params.result = 1;
 	FD_SET(ipc_socket, &read_select_params.readfds);
-	expect_value(__wrap_select, timeout, NULL);
+	expect_ptr_value(__wrap_select, timeout, NULL);
 	will_return(__wrap_select, &read_select_params);
 
 	read_message.type = TAPDISK_MESSAGE_CLOSE_RSP;
@@ -101,10 +102,10 @@ void test_tap_ctl_close_success(void **state)
 	read_message.u.response.error = 0;
 	read_params.result = sizeof(read_message);
 	read_params.data = &read_message;
-	expect_value(__wrap_read, fd, ipc_socket);
+	expect_int_value(__wrap_read, fd, ipc_socket);
 	will_return(__wrap_read, &read_params);
 
-	expect_value(__wrap_close, fd, ipc_socket);
+	expect_int_value(__wrap_close, fd, ipc_socket);
 	will_return(__wrap_close, 0);
 
 	/* Call test API */
@@ -136,29 +137,29 @@ void test_tap_ctl_force_close_success(void **state)
 	saddr.sun_family = AF_UNIX;
 	strcpy(saddr.sun_path, expected_sock_name);
 
-	expect_value(__wrap_socket, domain, AF_UNIX);
-	expect_value(__wrap_socket, type, SOCK_STREAM);
+	expect_int_value(__wrap_socket, domain, AF_UNIX);
+	expect_int_value(__wrap_socket, type, SOCK_STREAM);
 	expect_any(__wrap_socket, protocol);
 	will_return(__wrap_socket, ipc_socket);
 
-	expect_value(__wrap_connect, sockfd, ipc_socket);
+	expect_int_value(__wrap_connect, sockfd, ipc_socket);
 	expect_memory(__wrap_connect, addr, &saddr, sizeof(saddr));
 	will_return(__wrap_connect, 0);
 
 	write_select_params.result = 1;
 	FD_SET(ipc_socket, &write_select_params.writefds);
-	expect_value(__wrap_select, timeout, NULL);
+	expect_ptr_value(__wrap_select, timeout, NULL);
 	will_return(__wrap_select, &write_select_params);
 
 	write_message.type = TAPDISK_MESSAGE_FORCE_SHUTDOWN;
 	write_message.cookie = test_minor;
-	expect_value(__wrap_write, fd, ipc_socket);
+	expect_int_value(__wrap_write, fd, ipc_socket);
 	expect_memory(__wrap_write, buf, &write_message, sizeof(write_message));
 	will_return(__wrap_write, 1024);
 
 	read_select_params.result = 1;
 	FD_SET(ipc_socket, &read_select_params.readfds);
-	expect_value(__wrap_select, timeout, NULL);
+	expect_ptr_value(__wrap_select, timeout, NULL);
 	will_return(__wrap_select, &read_select_params);
 
 	read_message.type = TAPDISK_MESSAGE_CLOSE_RSP;
@@ -166,10 +167,10 @@ void test_tap_ctl_force_close_success(void **state)
 	read_message.u.response.error = 0;
 	read_params.result = sizeof(read_message);
 	read_params.data = &read_message;
-	expect_value(__wrap_read, fd, ipc_socket);
+	expect_int_value(__wrap_read, fd, ipc_socket);
 	will_return(__wrap_read, &read_params);
 
-	expect_value(__wrap_close, fd, ipc_socket);
+	expect_int_value(__wrap_close, fd, ipc_socket);
 	will_return(__wrap_close, 0);
 
 	/* Call test API */
@@ -191,16 +192,16 @@ void test_tap_ctl_close_connect_fail(void **state)
 	saddr.sun_family = AF_UNIX;
 	strcpy(saddr.sun_path, expected_sock_name);
 
-	expect_value(__wrap_socket, domain, AF_UNIX);
-	expect_value(__wrap_socket, type, SOCK_STREAM);
+	expect_int_value(__wrap_socket, domain, AF_UNIX);
+	expect_int_value(__wrap_socket, type, SOCK_STREAM);
 	expect_any(__wrap_socket, protocol);
 	will_return(__wrap_socket, ipc_socket);
 
-	expect_value(__wrap_connect, sockfd, ipc_socket);
+	expect_int_value(__wrap_connect, sockfd, ipc_socket);
 	expect_memory(__wrap_connect, addr, &saddr, sizeof(saddr));
 	will_return(__wrap_connect, ENOENT);
 
-	expect_value(__wrap_close, fd, ipc_socket);
+	expect_int_value(__wrap_close, fd, ipc_socket);
 	will_return(__wrap_close, 0);
 
 	/* Call test API */
@@ -227,25 +228,25 @@ void test_tap_ctl_close_write_error(void **state)
 	saddr.sun_family = AF_UNIX;
 	strcpy(saddr.sun_path, expected_sock_name);
 
-	expect_value(__wrap_socket, domain, AF_UNIX);
-	expect_value(__wrap_socket, type, SOCK_STREAM);
+	expect_int_value(__wrap_socket, domain, AF_UNIX);
+	expect_int_value(__wrap_socket, type, SOCK_STREAM);
 	expect_any(__wrap_socket, protocol);
 	will_return(__wrap_socket, ipc_socket);
 
-	expect_value(__wrap_connect, sockfd, ipc_socket);
+	expect_int_value(__wrap_connect, sockfd, ipc_socket);
 	expect_memory(__wrap_connect, addr, &saddr, sizeof(saddr));
 	will_return(__wrap_connect, 0);
 
 	write_select_params.result = 1;
 	FD_SET(ipc_socket, &write_select_params.writefds);
-	expect_value(__wrap_select, timeout, NULL);
+	expect_ptr_value(__wrap_select, timeout, NULL);
 	will_return(__wrap_select, &write_select_params);
 
-	expect_value(__wrap_write, fd, ipc_socket);
+	expect_int_value(__wrap_write, fd, ipc_socket);
 	expect_any(__wrap_write, buf);
 	will_return(__wrap_write, -EIO);
 
-	expect_value(__wrap_close, fd, ipc_socket);
+	expect_int_value(__wrap_close, fd, ipc_socket);
 	will_return(__wrap_close, 0);
 
 	/* Call test API */
@@ -275,37 +276,37 @@ void test_tap_ctl_close_read_error(void **state)
 	saddr.sun_family = AF_UNIX;
 	strcpy(saddr.sun_path, expected_sock_name);
 
-	expect_value(__wrap_socket, domain, AF_UNIX);
-	expect_value(__wrap_socket, type, SOCK_STREAM);
+	expect_int_value(__wrap_socket, domain, AF_UNIX);
+	expect_int_value(__wrap_socket, type, SOCK_STREAM);
 	expect_any(__wrap_socket, protocol);
 	will_return(__wrap_socket, ipc_socket);
 
-	expect_value(__wrap_connect, sockfd, ipc_socket);
+	expect_int_value(__wrap_connect, sockfd, ipc_socket);
 	expect_memory(__wrap_connect, addr, &saddr, sizeof(saddr));
 	will_return(__wrap_connect, 0);
 
 	write_select_params.result = 1;
 	FD_SET(ipc_socket, &write_select_params.writefds);
-	expect_value(__wrap_select, timeout, NULL);
+	expect_ptr_value(__wrap_select, timeout, NULL);
 	will_return(__wrap_select, &write_select_params);
 
 	write_message.type = TAPDISK_MESSAGE_CLOSE;
 	write_message.cookie = test_minor;
-	expect_value(__wrap_write, fd, ipc_socket);
+	expect_int_value(__wrap_write, fd, ipc_socket);
 	expect_memory(__wrap_write, buf, &write_message, sizeof(write_message));
 	will_return(__wrap_write, 1024);
 
 	read_select_params.result = 1;
 	FD_SET(ipc_socket, &read_select_params.readfds);
-	expect_value(__wrap_select, timeout, NULL);
+	expect_ptr_value(__wrap_select, timeout, NULL);
 	will_return(__wrap_select, &read_select_params);
 
 	read_params.result = -EIO;
 	read_params.data = NULL;
-	expect_value(__wrap_read, fd, ipc_socket);
+	expect_int_value(__wrap_read, fd, ipc_socket);
 	will_return(__wrap_read, &read_params);
 
-	expect_value(__wrap_close, fd, ipc_socket);
+	expect_int_value(__wrap_close, fd, ipc_socket);
 	will_return(__wrap_close, 0);
 
 	/* Call test API */
@@ -333,12 +334,12 @@ void test_tap_ctl_close_write_select_timeout(void **state)
 	saddr.sun_family = AF_UNIX;
 	strcpy(saddr.sun_path, expected_sock_name);
 
-	expect_value(__wrap_socket, domain, AF_UNIX);
-	expect_value(__wrap_socket, type, SOCK_STREAM);
+	expect_int_value(__wrap_socket, domain, AF_UNIX);
+	expect_int_value(__wrap_socket, type, SOCK_STREAM);
 	expect_any(__wrap_socket, protocol);
 	will_return(__wrap_socket, ipc_socket);
 
-	expect_value(__wrap_connect, sockfd, ipc_socket);
+	expect_int_value(__wrap_connect, sockfd, ipc_socket);
 	expect_memory(__wrap_connect, addr, &saddr, sizeof(saddr));
 	will_return(__wrap_connect, 0);
 
@@ -348,7 +349,7 @@ void test_tap_ctl_close_write_select_timeout(void **state)
 	expect_memory(__wrap_select, timeout, &write_timeout, sizeof(write_timeout));
 	will_return(__wrap_select, &write_select_params);
 
-	expect_value(__wrap_close, fd, ipc_socket);
+	expect_int_value(__wrap_close, fd, ipc_socket);
 	will_return(__wrap_close, 0);
 
 	/* Call test API */
@@ -379,12 +380,12 @@ void test_tap_ctl_close_read_select_timeout(void **state)
 	saddr.sun_family = AF_UNIX;
 	strcpy(saddr.sun_path, expected_sock_name);
 
-	expect_value(__wrap_socket, domain, AF_UNIX);
-	expect_value(__wrap_socket, type, SOCK_STREAM);
+	expect_int_value(__wrap_socket, domain, AF_UNIX);
+	expect_int_value(__wrap_socket, type, SOCK_STREAM);
 	expect_any(__wrap_socket, protocol);
 	will_return(__wrap_socket, ipc_socket);
 
-	expect_value(__wrap_connect, sockfd, ipc_socket);
+	expect_int_value(__wrap_connect, sockfd, ipc_socket);
 	expect_memory(__wrap_connect, addr, &saddr, sizeof(saddr));
 	will_return(__wrap_connect, 0);
 
@@ -397,7 +398,7 @@ void test_tap_ctl_close_read_select_timeout(void **state)
 
 	write_message.type = TAPDISK_MESSAGE_CLOSE;
 	write_message.cookie = test_minor;
-	expect_value(__wrap_write, fd, ipc_socket);
+	expect_int_value(__wrap_write, fd, ipc_socket);
 	expect_memory(__wrap_write, buf, &write_message, sizeof(write_message));
 	will_return(__wrap_write, 1024);
 
@@ -407,7 +408,7 @@ void test_tap_ctl_close_read_select_timeout(void **state)
 	expect_memory(__wrap_select, timeout, &read_timeout, sizeof(read_timeout));
 	will_return(__wrap_select, &read_select_params);
 
-	expect_value(__wrap_close, fd, ipc_socket);
+	expect_int_value(__wrap_close, fd, ipc_socket);
 	will_return(__wrap_close, 0);
 
 	/* Call test API */
@@ -439,29 +440,29 @@ void test_tap_ctl_close_error_response(void **state)
 	saddr.sun_family = AF_UNIX;
 	strcpy(saddr.sun_path, expected_sock_name);
 
-	expect_value(__wrap_socket, domain, AF_UNIX);
-	expect_value(__wrap_socket, type, SOCK_STREAM);
+	expect_int_value(__wrap_socket, domain, AF_UNIX);
+	expect_int_value(__wrap_socket, type, SOCK_STREAM);
 	expect_any(__wrap_socket, protocol);
 	will_return(__wrap_socket, ipc_socket);
 
-	expect_value(__wrap_connect, sockfd, ipc_socket);
+	expect_int_value(__wrap_connect, sockfd, ipc_socket);
 	expect_memory(__wrap_connect, addr, &saddr, sizeof(saddr));
 	will_return(__wrap_connect, 0);
 
 	write_select_params.result = 1;
 	FD_SET(ipc_socket, &write_select_params.writefds);
-	expect_value(__wrap_select, timeout, NULL);
+	expect_ptr_value(__wrap_select, timeout, NULL);
 	will_return(__wrap_select, &write_select_params);
 
 	write_message.type = TAPDISK_MESSAGE_CLOSE;
 	write_message.cookie = test_minor;
-	expect_value(__wrap_write, fd, ipc_socket);
+	expect_int_value(__wrap_write, fd, ipc_socket);
 	expect_memory(__wrap_write, buf, &write_message, sizeof(write_message));
 	will_return(__wrap_write, 1024);
 
 	read_select_params.result = 1;
 	FD_SET(ipc_socket, &read_select_params.readfds);
-	expect_value(__wrap_select, timeout, NULL);
+	expect_ptr_value(__wrap_select, timeout, NULL);
 	will_return(__wrap_select, &read_select_params);
 
 	read_message.type = TAPDISK_MESSAGE_ERROR;
@@ -469,10 +470,10 @@ void test_tap_ctl_close_error_response(void **state)
 	read_message.u.response.error = ENOENT;
 	read_params.result = sizeof(read_message);
 	read_params.data = &read_message;
-	expect_value(__wrap_read, fd, ipc_socket);
+	expect_int_value(__wrap_read, fd, ipc_socket);
 	will_return(__wrap_read, &read_params);
 
-	expect_value(__wrap_close, fd, ipc_socket);
+	expect_int_value(__wrap_close, fd, ipc_socket);
 	will_return(__wrap_close, 0);
 
 	/* Call test API */

--- a/mockatests/control/test-tap-ctl-free.c
+++ b/mockatests/control/test-tap-ctl-free.c
@@ -32,6 +32,7 @@
 #include <stdarg.h>
 #include <setjmp.h>
 #include <cmocka.h>
+#include <cmocka-compat.h>
 #include <errno.h>
 
 #include <wrappers.h>
@@ -63,11 +64,11 @@ void test_tap_ctl_free_success(void **state)
 	expect_string(__wrap_open, pathname, "/dev/xen/blktap-2/control");
 
 	will_return(__wrap_ioctl, 0);
-	expect_value(__wrap_ioctl, fd, dev_fd);
-	expect_value(__wrap_ioctl, request, BLKTAP2_IOCTL_FREE_TAP);
+	expect_int_value(__wrap_ioctl, fd, dev_fd);
+	expect_int_value(__wrap_ioctl, request, BLKTAP2_IOCTL_FREE_TAP);
 
 	will_return(__wrap_close, 0);
-	expect_value(__wrap_close, fd, dev_fd);
+	expect_int_value(__wrap_close, fd, dev_fd);
 
 	result = tap_ctl_free(0);
 
@@ -83,11 +84,11 @@ void test_tap_ctl_free_ioctl_busy(void **state)
 	expect_string(__wrap_open, pathname, "/dev/xen/blktap-2/control");
 
 	will_return(__wrap_ioctl, EBUSY);
-	expect_value(__wrap_ioctl, fd, dev_fd);
-	expect_value(__wrap_ioctl, request, BLKTAP2_IOCTL_FREE_TAP);
+	expect_int_value(__wrap_ioctl, fd, dev_fd);
+	expect_int_value(__wrap_ioctl, request, BLKTAP2_IOCTL_FREE_TAP);
 
 	will_return(__wrap_close, 0);
-	expect_value(__wrap_close, fd, dev_fd);
+	expect_int_value(__wrap_close, fd, dev_fd);
 
 	result = tap_ctl_free(0);
 

--- a/mockatests/control/util.c
+++ b/mockatests/control/util.c
@@ -33,6 +33,7 @@
 #include <string.h>
 #include <setjmp.h>
 #include <cmocka.h>
+#include <cmocka-compat.h>
 #include <errno.h>
 
 #include <sys/un.h>
@@ -80,12 +81,12 @@ struct mock_ipc_params *setup_ipc(char *ipc_socket_name, int ipc_socket_fd,
 	ipc_params->saddr.sun_family = AF_UNIX;
 	strcpy(ipc_params->saddr.sun_path, ipc_socket_name);
 
-	expect_value(__wrap_socket, domain, AF_UNIX);
-	expect_value(__wrap_socket, type, SOCK_STREAM);
+	expect_int_value(__wrap_socket, domain, AF_UNIX);
+	expect_int_value(__wrap_socket, type, SOCK_STREAM);
 	expect_any(__wrap_socket, protocol);
 	will_return(__wrap_socket, ipc_socket_fd);
 
-	expect_value(__wrap_connect, sockfd, ipc_socket_fd);
+	expect_int_value(__wrap_connect, sockfd, ipc_socket_fd);
 	expect_memory(__wrap_connect, addr,
 		      &(ipc_params->saddr), sizeof(ipc_params->saddr));
 	will_return(__wrap_connect, 0);
@@ -95,7 +96,7 @@ struct mock_ipc_params *setup_ipc(char *ipc_socket_name, int ipc_socket_fd,
 	expect_any(__wrap_select, timeout);
 	will_return(__wrap_select, &(ipc_params->write_select_params));
 
-	expect_value(__wrap_write, fd, ipc_socket_fd);
+	expect_int_value(__wrap_write, fd, ipc_socket_fd);
 	expect_memory(__wrap_write, buf,
 		      &(ipc_params->write_message), sizeof(tapdisk_message_t));
 	will_return(__wrap_write, 1024);
@@ -114,11 +115,11 @@ struct mock_ipc_params *setup_ipc(char *ipc_socket_name, int ipc_socket_fd,
 
 		ipc_params->read_params[id].result = sizeof(*read_message);
 		ipc_params->read_params[id].data = &(ipc_params->read_message[id]);
-		expect_value(__wrap_read, fd, ipc_socket_fd);
+		expect_int_value(__wrap_read, fd, ipc_socket_fd);
 		will_return(__wrap_read, &(ipc_params->read_params[id]));
 	}
 
-	expect_value(__wrap_close, fd, ipc_socket_fd);
+	expect_int_value(__wrap_close, fd, ipc_socket_fd);
 	will_return(__wrap_close, 0);
 
 	return ipc_params;

--- a/mockatests/drivers/test-tapdisk-nbdserver.c
+++ b/mockatests/drivers/test-tapdisk-nbdserver.c
@@ -32,6 +32,7 @@
 #include <stdarg.h>
 #include <setjmp.h>
 #include <cmocka.h>
+#include <cmocka-compat.h>
 #include <stdlib.h>
 
 #include "test-suites.h"
@@ -55,15 +56,15 @@ test_nbdserver_new_protocol_handshake(void **state)
 
 	/* Check input to send */
 	expect_memory(__wrap_send, buf, &handshake, sizeof(handshake));
-	expect_value(__wrap_send, fd, new_fd);
-	expect_value(__wrap_send, size, sizeof(handshake));
-	expect_value(__wrap_send, flags, 0);
+	expect_int_value(__wrap_send, fd, new_fd);
+	expect_uint_value(__wrap_send, size, sizeof(handshake));
+	expect_int_value(__wrap_send, flags, 0);
 	will_return(__wrap_send, sizeof(handshake));
 
 	client.server = &server;
 
-	expect_value(__wrap_tapdisk_server_register_event, cb, tapdisk_nbdserver_handshake_cb);
-	expect_value(__wrap_tapdisk_server_register_event, mode, SCHEDULER_POLL_READ_FD);
+	expect_ptr_value(__wrap_tapdisk_server_register_event, cb, tapdisk_nbdserver_handshake_cb);
+	expect_int_value(__wrap_tapdisk_server_register_event, mode, SCHEDULER_POLL_READ_FD);
 	int err = tapdisk_nbdserver_new_protocol_handshake(&client, new_fd);
 	assert_int_equal(err, 0);
 }

--- a/mockatests/drivers/vbd-wrappers.c
+++ b/mockatests/drivers/vbd-wrappers.c
@@ -33,6 +33,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
+#include <cmocka-compat.h>
+
 #include "tapdisk.h"
 #include "tapdisk-interface.h"
 
@@ -45,16 +47,16 @@ __wrap_tapdisk_image_check_request(td_image_t *image, td_vbd_request_t *vreq)
 void
 __wrap_td_queue_block_status(td_image_t *image, td_request_t *treq)
 {
-	check_expected(treq);
+	check_expected_ptr(treq);
 }
 
 int
 __wrap_send(int fd, void* buf, size_t size, int flags)
 {
-	check_expected(buf);
-	check_expected(fd);
-	check_expected(size);
-	check_expected(flags);
+	check_expected_ptr(buf);
+	check_expected_int(fd);
+	check_expected_uint(size);
+	check_expected_int(flags);
 	return (int)mock();
 }
 
@@ -62,7 +64,7 @@ event_id_t
 __wrap_tapdisk_server_register_event(char mode, int fd,
                               struct timeval timeout, event_cb_t cb, void *data)
 {
-	check_expected(mode);
+	check_expected_int(mode);
 	check_expected_ptr(cb);
 	return 0;
 }

--- a/mockatests/include/cmocka-compat.h
+++ b/mockatests/include/cmocka-compat.h
@@ -68,4 +68,17 @@
 # define check_expected_ptr(parameter) check_expected(parameter)
 #endif
 
+#ifndef assert_int_in_range
+# define assert_int_in_range(value, minimum, maximum) \
+	assert_in_range(value, minimum, maximum)
+#endif
+#ifndef will_return_int_always
+# define will_return_int_always(function, value) \
+	will_return_always(function, value)
+#endif
+#ifndef will_return_ptr_always
+# define will_return_ptr_always(function, value) \
+	will_return_always(function, value)
+#endif
+
 #endif /* __CMOCKA_COMPAT_H__ */

--- a/mockatests/include/cmocka-compat.h
+++ b/mockatests/include/cmocka-compat.h
@@ -58,4 +58,14 @@
 	expect_value_count(function, parameter, value, count)
 #endif
 
+#ifndef check_expected_int
+# define check_expected_int(parameter) check_expected(parameter)
+#endif
+#ifndef check_expected_uint
+# define check_expected_uint(parameter) check_expected(parameter)
+#endif
+#ifndef check_expected_ptr
+# define check_expected_ptr(parameter) check_expected(parameter)
+#endif
+
 #endif /* __CMOCKA_COMPAT_H__ */

--- a/mockatests/include/cmocka-compat.h
+++ b/mockatests/include/cmocka-compat.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026, Vates SAS.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __CMOCKA_COMPAT_H__
+#define __CMOCKA_COMPAT_H__
+
+#include <cmocka.h>
+
+/*
+ * Newer cmocka releases deprecate some macros, and -Werror=deprecated-declarations
+ * turns the warning into a build failure.
+ * Fall back to the old macros when the new ones aren't available.
+ */
+#ifndef expect_int_value
+# define expect_int_value(function, parameter, value) \
+	expect_value(function, parameter, value)
+#endif
+
+#ifndef expect_uint_value
+# define expect_uint_value(function, parameter, value) \
+	expect_value(function, parameter, value)
+#endif
+
+#ifndef expect_ptr_value
+# define expect_ptr_value(function, parameter, value) \
+	expect_uint_value(function, parameter, (uintptr_t)value)
+#endif
+
+#ifndef expect_uint_value_count
+# define expect_uint_value_count(function, parameter, value, count) \
+	expect_value_count(function, parameter, value, count)
+#endif
+
+#endif /* __CMOCKA_COMPAT_H__ */

--- a/mockatests/vhd/test-vhd-util-snapshot.c
+++ b/mockatests/vhd/test-vhd-util-snapshot.c
@@ -31,6 +31,7 @@
 #include <stdarg.h>
 #include <setjmp.h>
 #include <cmocka.h>
+#include <cmocka-compat.h>
 #include <errno.h>
 #include <wrappers.h>
 
@@ -121,10 +122,10 @@ void test_vhd_util_snapshot_einval_from_vhd_set_keyhash(void **state)
 {
 	will_return(__wrap_canonpath, "testing");
 	will_return(__wrap_vhd_snapshot, 0);
-	will_return_always(__wrap_vhd_open, 0);
+	will_return_int_always(__wrap_vhd_open, 0);
 	set_cookie();
 	will_return(__wrap_vhd_get_keyhash, 0);
-	will_return_always(__wrap_vhd_close, 0);
+	will_return_int_always(__wrap_vhd_close, 0);
 	will_return(__wrap_vhd_set_keyhash, EINVAL);
 	expect_any_count(__wrap_vhd_close, ctx, 2);
 	expect_any(__wrap_free, ptr);

--- a/mockatests/vhd/vhd-wrappers.c
+++ b/mockatests/vhd/vhd-wrappers.c
@@ -33,6 +33,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
+#include <cmocka-compat.h>
+
 #include "libvhd.h"
 #include "vhd-wrappers.h"
 
@@ -104,7 +106,7 @@ int __wrap_vhd_get_keyhash(vhd_context_t *ctx, struct vhd_keyhash* hash)
 
 int __wrap_vhd_close(vhd_context_t *ctx)
 {
-	check_expected(ctx);
+	check_expected_ptr(ctx);
 	close_count++;
 	return (int)mock();
 }
@@ -160,7 +162,7 @@ __wrap_free(void *ptr)
 		/*fprintf(stderr, "Freeing block at %p\n", ptr);*/
 		test_free(ptr);
 	} else {
-		check_expected(ptr);
+		check_expected_ptr(ptr);
 		__real_free(ptr);
 	}
 }

--- a/mockatests/wrappers/wrappers.c
+++ b/mockatests/wrappers/wrappers.c
@@ -35,6 +35,7 @@
 #include <stddef.h>
 #include <setjmp.h>
 #include <cmocka.h>
+#include <cmocka-compat.h>
 #include <errno.h>
 
 #include <wrappers.h>
@@ -123,7 +124,7 @@ __wrap_fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream)
 		size_t remaining = data->size - data->offset;
 		size_t len = size * nmemb;
 
-		assert_in_range(len, 0, remaining);
+		assert_int_in_range(len, 0, remaining);
 		memcpy(data->buf + data->offset, ptr, len);
 
 		data->offset += len;
@@ -147,7 +148,7 @@ struct fwrite_data *setup_fwrite_mock(int size)
 	data->buf = buf;
 	data->type = stdout;
 
-	will_return_always(__wrap_fwrite, data);
+	will_return_ptr_always(__wrap_fwrite, data);
 
 	return data;
 }
@@ -167,7 +168,7 @@ wrap_vprintf(const char *format, va_list ap)
 		struct printf_data *data = mock_ptr_type(struct printf_data *);
 		int remaining = data->size - data->offset;
 		int len = vsnprintf(data->buf + data->offset, remaining, format, ap);
-		assert_in_range(len, 0, remaining);
+		assert_int_in_range(len, 0, remaining);
 		data->offset += len;
 		return len;
 	} else {
@@ -224,7 +225,7 @@ struct printf_data *setup_vprintf_mock(int size)
 	data->offset = 0;
 	data->buf = buf;
 
-	will_return_always(wrap_vprintf, data);
+	will_return_ptr_always(wrap_vprintf, data);
 
 	mock_vprintf = 1;
 


### PR DESCRIPTION
This should be the last thing needed to build on recent Linux destribution.
Doesn't break build on CI or on XCP-ng host.