### PR TITLE
qcow2: fix the commit-filter use-after-free behind the coalesce crashes (needs a companion fix so sm can see failed coalesces)

### DIFF
--- a/drivers/block-qcow2.c
+++ b/drivers/block-qcow2.c
@@ -170,6 +170,7 @@ struct qcow2_state {
 	pthread_mutex_t           lock;
 	pthread_cond_t            cond;
 	bool                      driver_opened;
+	bool                      open_done;
 	int                       open_status;
 	MemReentrancyGuard        mem_reentrancy_guard;
 
@@ -435,6 +436,7 @@ qcow2_open(void *opaque)
 
 	pthread_mutex_lock(&s->lock);
 	s->open_status = 0;
+	s->open_done = true;
 	pthread_cond_signal(&s->cond);
 
 	while (s->driver_opened) {
@@ -444,8 +446,42 @@ qcow2_open(void *opaque)
 	}
 	pthread_mutex_unlock(&s->lock);
 
+	/*
+	 * Nothing must outlive this thread: the BlockBackend, the AioContext and
+	 * the driver state are all torn down below. A job that is still live
+	 * here would keep references to them, so cancel it before dismissing it.
+	 * job_dismiss_locked() only accepts a concluded job, which is why it used
+	 * to fail with "job dismiss error" and leave the job behind.
+	 */
 	job_lock();
 	BlockJob *bjob = block_job_get_locked(COMMIT_JOB_ID);
+	if (bjob) {
+		/*
+		 * Same restriction as do_cancel_commit_job(): only the states
+		 * where the job is started and stays alive on its own. The
+		 * transient finalization states cannot be observed here, because
+		 * the job is created with auto_finalize and this code runs with
+		 * an empty stack, not from the nested poll inside a finalize.
+		 * Force-cancel: this is the last chance to stop the job before
+		 * everything it references is destroyed below.
+		 */
+		switch (bjob->job.status) {
+		case JOB_STATUS_RUNNING:
+		case JOB_STATUS_PAUSED:
+		case JOB_STATUS_READY:
+		case JOB_STATUS_STANDBY: {
+			int cancel_err = job_cancel_sync_locked(&bjob->job, true);
+			if (cancel_err && cancel_err != -ECANCELED)
+				DPRINTF("Qcow2: job cancel error at close: %d\n", cancel_err);
+			break;
+		}
+		default:
+			break;
+		}
+
+		/* The cancel may have dismissed and freed the job already. */
+		bjob = block_job_get_locked(COMMIT_JOB_ID);
+	}
 	if (bjob) {
 		Job *job = &bjob->job;
 		job_dismiss_locked(&job, &local_err);
@@ -482,6 +518,7 @@ qcow2_open(void *opaque)
 
 	pthread_mutex_lock(&s->lock);
 	s->open_status = -EINVAL;
+	s->open_done = true;
 	pthread_cond_signal(&s->cond);
 	pthread_mutex_unlock(&s->lock);
 
@@ -527,11 +564,27 @@ _qcow2_open(td_driver_t *driver, const char *name,
 	qemu_thread_create(&s->thread, "td-qcow2", qcow2_open, s,
 			   QEMU_THREAD_JOINABLE);
 
-	pthread_cond_wait(&s->cond, &s->lock);
+	while (!s->open_done)
+		pthread_cond_wait(&s->cond, &s->lock);
 	err = s->open_status;
 	s->open_status = 0;
 	pthread_mutex_unlock(&s->lock);
 
+	if (err) {
+		/*
+		 * The thread tears the QEMU globals down (main loop, BQL, CPU
+		 * loop) on its way out. tapdisk frees the driver state and
+		 * retries the open right away, so wait for it to be gone before
+		 * returning: otherwise the next attempt re-initializes those
+		 * globals while this thread is still destroying them.
+		 */
+		qemu_thread_join(&s->thread);
+
+		pthread_cond_destroy(&s->commit_cond);
+		pthread_mutex_destroy(&s->commit_lock);
+		pthread_cond_destroy(&s->cond);
+		pthread_mutex_destroy(&s->lock);
+	}
 
 	return err;
 }
@@ -546,11 +599,19 @@ _qcow2_close(td_driver_t *driver)
 
 	DBG(TLOG_WARN, "qcow2_close\n");
 
+	/*
+	 * Kick the thread while still holding the lock. The thread can only
+	 * observe driver_opened == false with s->lock held, hence only once this
+	 * has released it, so the bottom half is guaranteed to still exist when
+	 * it is scheduled here. Kicking after the unlock instead leaves a window
+	 * where the thread has already left its loop, deleted the bottom half
+	 * and finalized the AioContext, and the kick writes into freed memory
+	 * and notifies a destroyed event notifier.
+	 */
 	pthread_mutex_lock(&s->lock);
 	s->driver_opened = false;
-	pthread_mutex_unlock(&s->lock);
-
 	qemu_bh_schedule(s->bh);
+	pthread_mutex_unlock(&s->lock);
 
 	// Ignore return, qcow2_open() always return NULL; or will abort
 	qemu_thread_join(&s->thread);
@@ -1155,13 +1216,52 @@ do_cancel_commit_job(struct qcow2_state *s, struct qcow2_request *req)
 		goto signal;
 	}
 
-	if (bjob->job.status == JOB_STATUS_RUNNING ||
-		bjob->job.status == JOB_STATUS_READY) {
+	/*
+	 * Cancel the job in every state where it is started and can stay alive
+	 * on its own. Restricting this to RUNNING and READY made the cancel a
+	 * silent no-op that still reported success for a paused or standby job,
+	 * and the caller (typically _qcow2_close()) then tore the BlockBackend
+	 * and the AioContext down underneath it.
+	 *
+	 * CREATED, WAITING, PENDING and ABORTING are deliberately excluded even
+	 * though the verb table allows some of them. The job is created with
+	 * auto_finalize, so those states only exist while commit_start() or the
+	 * finalization sequence is on the stack, and this handler can be reached
+	 * from the nested aio_bh_poll() that bdrv_graph_wrunlock() performs
+	 * inside them. Cancelling there re-enters job_finalize_single_locked()
+	 * on a job that is already being finalized: the job state machine
+	 * asserts, the transaction is unreferenced twice, and commit_abort()
+	 * runs on half-initialized or already-cleaned job state.
+	 */
+	switch (bjob->job.status) {
+	case JOB_STATUS_RUNNING:
+	case JOB_STATUS_PAUSED:
+	case JOB_STATUS_READY:
+	case JOB_STATUS_STANDBY:
 		if (req->sync == false) {
 			job_cancel_locked(&bjob->job, false);
 		} else {
+			/*
+			 * The job may be dismissed and freed by the cancel, so
+			 * bjob must not be used afterwards.
+			 */
 			err = job_cancel_sync_locked(&bjob->job, false);
 		}
+		break;
+	case JOB_STATUS_CONCLUDED:
+		/* Already finished, nothing left to cancel. */
+		DPRINTF("Qcow2: job already concluded.\n");
+		break;
+	default:
+		/*
+		 * Mid-finalization. Do not report this as a successful cancel:
+		 * the job is about to complete, and telling the caller it was
+		 * cancelled would have it believe the chain was left alone.
+		 */
+		DPRINTF("Qcow2: not cancelling job in state '%s'.\n",
+			JobStatus_str(bjob->job.status));
+		err = -EBUSY;
+		break;
 	}
 	job_unlock();
 

--- a/drivers/block-qcow2.c
+++ b/drivers/block-qcow2.c
@@ -110,6 +110,11 @@ struct qcow2_request;
 
 struct qcow2_request {
 	int                     error;
+	/*
+	 * Predicate for the control operations (commit, query, cancel): set by
+	 * the qcow2 thread under commit_lock once error/job_info are valid.
+	 */
+	bool                    done;
 	enum qcow2_ops          op;
 	union {
 		/* OP_READ, OP_WRITE */
@@ -527,6 +532,7 @@ _qcow2_open(td_driver_t *driver, const char *name,
 	s->open_status = 0;
 	pthread_mutex_unlock(&s->lock);
 
+
 	return err;
 }
 
@@ -916,15 +922,26 @@ qcow2_commit(td_driver_t *driver, const char *name)
 
 	req->top   = strdup(name);
 	req->op    = QCOW2_OP_COMMIT;
+	req->error = 0;
+	req->done  = false;
+
+	/*
+	 * Lock order is commit_lock -> lock, and never the reverse: the qcow2
+	 * thread releases lock before dispatching a request, so no handler takes
+	 * commit_lock while holding lock. Holding commit_lock across the publish
+	 * is belt and braces on top of the done predicate below; the predicate
+	 * alone would already stop the wakeup from being lost.
+	 */
+	pthread_mutex_lock(&s->commit_lock);
 
 	pthread_mutex_lock(&s->lock);
 	QSIMPLEQ_INSERT_TAIL(&s->inflight, req, list);
 	pthread_mutex_unlock(&s->lock);
 
-	pthread_mutex_lock(&s->commit_lock);
 	qemu_bh_schedule(s->bh);
 
-	pthread_cond_wait(&s->commit_cond, &s->commit_lock);
+	while (!req->done)
+		pthread_cond_wait(&s->commit_cond, &s->commit_lock);
 	err = req->error;
 	pthread_mutex_unlock(&s->commit_lock);
 
@@ -977,7 +994,8 @@ do_commit(struct qcow2_state *s, struct qcow2_request *req)
 signal_commit:
 	pthread_mutex_lock(&s->commit_lock);
 	req->error = err;
-	pthread_cond_signal(&s->commit_cond);
+	req->done  = true;
+	pthread_cond_broadcast(&s->commit_cond);
 	pthread_mutex_unlock(&s->commit_lock);
 }
 
@@ -995,15 +1013,19 @@ qcow2_query_commit_job(td_driver_t *driver, td_query_t *query)
 		return -EBUSY;
 
 	req->op    = QCOW2_OP_QUERY;
+	req->error = 0;
+	req->done  = false;
+
+	pthread_mutex_lock(&s->commit_lock);
 
 	pthread_mutex_lock(&s->lock);
 	QSIMPLEQ_INSERT_TAIL(&s->inflight, req, list);
 	pthread_mutex_unlock(&s->lock);
 
-	pthread_mutex_lock(&s->commit_lock);
 	qemu_bh_schedule(s->bh);
 
-	pthread_cond_wait(&s->commit_cond, &s->commit_lock);
+	while (!req->done)
+		pthread_cond_wait(&s->commit_cond, &s->commit_lock);
 
 	if (query) {
 		query->status = JobStatus_str(s->job_info.status);
@@ -1071,12 +1093,13 @@ signal:
 	s->job_info.total_progress = total;
 
 	req->error = err;
-	pthread_cond_signal(&s->commit_cond);
+	req->done  = true;
+	pthread_cond_broadcast(&s->commit_cond);
 	pthread_mutex_unlock(&s->commit_lock);
 }
 
 
-int
+static int
 qcow2_cancel_commit_job(td_driver_t *driver, bool wait)
 {
 	struct qcow2_state *s = (struct qcow2_state *)driver->data;
@@ -1089,17 +1112,21 @@ qcow2_cancel_commit_job(td_driver_t *driver, bool wait)
 	if (!req)
 		return -EBUSY;
 
-	req->op   = QCOW2_OP_CANCEL_COMMIT;
-	req->sync = wait;
+	req->op    = QCOW2_OP_CANCEL_COMMIT;
+	req->sync  = wait;
+	req->error = 0;
+	req->done  = false;
+
+	pthread_mutex_lock(&s->commit_lock);
 
 	pthread_mutex_lock(&s->lock);
 	QSIMPLEQ_INSERT_TAIL(&s->inflight, req, list);
 	pthread_mutex_unlock(&s->lock);
 
-	pthread_mutex_lock(&s->commit_lock);
 	qemu_bh_schedule(s->bh);
 
-	pthread_cond_wait(&s->commit_cond, &s->commit_lock);
+	while (!req->done)
+		pthread_cond_wait(&s->commit_cond, &s->commit_lock);
 	err = req->error;
 	pthread_mutex_unlock(&s->commit_lock);
 
@@ -1143,7 +1170,8 @@ do_cancel_commit_job(struct qcow2_state *s, struct qcow2_request *req)
 signal:
 	pthread_mutex_lock(&s->commit_lock);
 	req->error = err;
-	pthread_cond_signal(&s->commit_cond);
+	req->done  = true;
+	pthread_cond_broadcast(&s->commit_cond);
 	pthread_mutex_unlock(&s->commit_lock);
 }
 

--- a/qcow2/lib/block/commit.c
+++ b/qcow2/lib/block/commit.c
@@ -99,8 +99,13 @@ static void commit_abort(Job *job)
      * something to base, the intermediate images aren't valid any more. */
     bdrv_graph_rdlock_main_loop();
     if (!s->commit_top_bs->backing) {
+        /*
+         * Defensive only: a live node never loses its backing child, and the
+         * reference taken in commit_start() keeps this one alive. If this ever
+         * fires, the lifetime assumption above is wrong.
+         */
         bdrv_graph_rdunlock_main_loop();
-        return;
+        goto cleanup;
     }
     commit_top_backing_bs = s->commit_top_bs->backing->bs;
     bdrv_graph_rdunlock_main_loop();
@@ -111,6 +116,7 @@ static void commit_abort(Job *job)
     bdrv_graph_wrunlock();
     bdrv_drained_end(commit_top_backing_bs);
 
+cleanup:
     bdrv_unref(s->commit_top_bs);
     bdrv_unref(top_bs);
 }
@@ -128,6 +134,19 @@ static void commit_clean(Job *job)
 
     g_free(s->backing_file_str);
     blk_unref(s->top);
+
+    /*
+     * Release the reference taken in commit_start(). On the success path the
+     * filter node is already detached from its parents, so this is the last
+     * reference to it. Clear the pointer before dropping the reference: the
+     * deletion polls the event loop, and nothing reached from there must find
+     * s->commit_top_bs pointing at a node that is midway through being freed.
+     */
+    if (s->commit_top_bs) {
+        BlockDriverState *commit_top_bs = s->commit_top_bs;
+        s->commit_top_bs = NULL;
+        bdrv_unref(commit_top_bs);
+    }
 }
 
 static int coroutine_fn commit_run(Job *job, Error **errp)
@@ -330,12 +349,19 @@ void commit_start(const char *job_id, BlockDriverState *bs,
     commit_top_bs->total_sectors = top->total_sectors;
 
     ret = bdrv_append(commit_top_bs, top, errp);
-    bdrv_unref(commit_top_bs); /* referenced by new parents or failed */
     if (ret < 0) {
+        bdrv_unref(commit_top_bs);
         commit_top_bs = NULL;
         goto fail;
     }
 
+    /*
+     * Keep the creation reference for the whole lifetime of the job instead of
+     * relying on the parent links alone: bdrv_drop_intermediate() moves those
+     * parents to base and then drops the last reference, which deletes the
+     * node while s->commit_top_bs still points at it. commit_abort() would
+     * then run on freed memory. The reference is released in commit_clean().
+     */
     s->commit_top_bs = commit_top_bs;
 
     /*
@@ -446,6 +472,11 @@ fail:
         bdrv_replace_node(commit_top_bs, top, &error_abort);
         bdrv_graph_wrunlock();
         bdrv_drained_end(top);
+        /*
+         * commit_clean() does not run for a job that failed to start, so the
+         * reference kept for the job lifetime is released here.
+         */
+        bdrv_unref(commit_top_bs);
     }
 }
 


### PR DESCRIPTION
**Draft — compiles, but never run. Please read the verification section before considering this for a release.**

---

> ## ⚠️ Do not ship this alone: sm still cannot tell a failed coalesce from a successful one
>
> This series stops tapdisk from crashing when a coalesce fails at its last step. It does **not** make that failure visible to the storage manager, and fixing the crash makes the gap more dangerous than it was.
>
> `td_query` carries the job's *status* and *progress*, never `job->ret`. With the crash fixed, a coalesce whose graph change was applied but whose backing-file header rewrite failed now ends as **`concluded` at 100% progress**, within microseconds, because the data copy genuinely did finish. sm polls, sees exactly what a success looks like, and proceeds as if the coalesce had worked.
>
> What that costs is not dangling children. sm compares each child's real on-disk parent against the expected one (`cleanup.py`, `real_parent_uuid == vdi.parent.uuid`): the children that **match** are recorded as already relinked by tapdisk and skipped, and the ones that **do not** go through the normal relink path, which rewrites their backing pointers. So after a failed coalesce sm relinks the children itself — believing the coalesce worked. The cost is that it **re-points children at a base image that may only be partially populated** (when the failure happened during the copy rather than at the header rewrite), rewrites the backing file of an image that may be open by a tapdisk on another host, and then deletes the coalesced VDI unconditionally, with the failure never reported anywhere.
>
> Before this series that case crashed tapdisk, which sm noticed. After it, the same case is silent. **We would be trading a visible crash for silent metadata divergence.**
>
> This is not hypothetical — it is what the current sm code does. `QCow2Util.coalesceOnline()` (`drivers/qcow2util.py` on `3.2.12-8.3-devel`) polls until the status string is `concluded` and then returns the byte count as the success value, with no error check anywhere in the loop:
>
> ```python
> status, nb, _ = TapCtl.query(pid, minor)
> if status == "undefined":          # only checked on the first query
>     return 0
> while status != "concluded":
>     time.sleep(1)
>     status, nb, _ = TapCtl.query(pid, minor, quiet=True)
> return nb
> ```
>
> `TapCtl.query()` (`drivers/blktap2.py`) parses only `Commit status '<status>' (<n>/<total>)`, so there is no error to check even if the loop wanted to. An aborted commit and a successful one are indistinguishable to sm today.
>
> Fixing it needs two changes, neither of them in this PR:
> 1. **tapdisk** — proposed in **#16**, which is stacked on this branch: carry the commit job's result in the query response.
> 2. **sm** — treat a coalesce as successful only when that result is absent, rather than inferring it from `concluded` + progress. This does not exist yet.
>
> So merging this PR *and* #16 does **not** on its own lift the hazard described above: without the sm side, the result is reported but nobody reads it. The remaining ship gate is item 2.
>
> Related, and in the same conversation: `bdrv_drop_intermediate()` still reports total and partial failures identically (the `FIXME` above `commit_prepare()`), so **sm must not assume a failed `qcow2_commit` left the chain untouched** — in the partial case the re-parenting has already happened in memory.

---

## Field evidence (added after the first review round)

Support bundles from one hosting provider — 21 bug reports, 6 hosts, 32 tapdisk coredumps — corroborate this, and narrow it:

- **The crash occurs only on the 9.3 build.** Zero tapdisk segfaults on any host running 6.7, including hosts whose logs are large and full of coalesce activity. Hosts that were quiet on 6.7 started crashing after being moved to 9.3: one goes 0 → 0 → 2 → 3 → 4 segfaults across successive reports, another 0 → 1 → 4. **The build shipped to stop a crash is what introduced crashes on those hosts.**
- **Every segfault is in `libqcow2`**, at the *same instruction offset* every time — deterministic, not a wild pointer.
- **The fault is a write to NULL**: `segfault at 0 … error 6` (user mode, write, page not present). That is what a second `QTAILQ_REMOVE` on an already-removed node does when the first removal NULLed the link — i.e. the double `bdrv_delete` described below. A read fault (`error 4`) would point somewhere else entirely.
- **It happens during coalesce**: kernel logs a tapdisk thread dying at `18:26:08`; sm logs `Couldn't coalesce online … tap-ctl query -p <that process>` at `18:26:09`.
- **One customer has on-disk damage**: 36 × `Parent of QCOW2-… wasn't found during scan`, a VDI that can no longer be activated, and a failing VM clone.

Two things the bundles **disproved**, both of which this PR previously implied:

1. **Out of space is not the trigger.** There is no ENOSPC on the affected hosts at all. What makes the header rewrite fail is still unknown; the bug does not depend on the reason.
2. The affected SRs are **LVM over FC**, not thin file SRs.

**Not fixed by this PR, and more common in the field:** a separate failure where sm *refuses* to coalesce (`Multiple openers for /dev/VG_XenStorage-…/QCOW2-…`), which appears on **both** builds and predates all of this. Chains then never shorten and backups fail on "unhealthy VDI chain". It is worth knowing that this is what most of those end customers are actually hitting — fixing the crash will not fix it. There is a hypothesis worth testing that it is caused by the reference leak this PR removes (a leaked image stays open, so a later snapshot makes a second opener); the check is to list which PIDs hold the LV open and see whether one belongs to a tapdisk whose VBD no longer needs it. If that is what it is, **this PR may fix that too** — which would be worth confirming before the fix is described to anyone.

## Acceptance test from the field data

After this PR, on a host that was crashing, the signature above must disappear: no `tapdisk … segfault at 0 … in libqcow2.so`. That is a cheap, unambiguous regression check that does not require reproducing the original failure.

## What this fixes

An online qcow2 coalesce finalizes in two steps: `bdrv_drop_intermediate()` first switches every parent of the commit filter node over to `base`, then rewrites the overlay's backing-file header. The first step drops the last reference to the filter node, so the node is **deleted and freed inside `commit_prepare()`**. If the second step then fails — ENOSPC, an I/O error, or a read-only reopen failure — the job aborts, and `commit_abort()` runs on `s->commit_top_bs`, which is now a dangling pointer.

That is the crash `0044-libqcow2-fix-abort-commit-without-crash.patch` was papering over: its `if (!s->commit_top_bs->backing) return;` guard "works" only because the freed node usually reads back as zeroed. It is a use-after-free read, and it leaks the `bdrv_ref(top_bs)` taken a few lines earlier, which is where the "logical volume in use" / stale-fd behaviour after a failed coalesce comes from.

It also means the follow-up fixup (`3.55.5-9.3`, "Fix libqcow2 crash on close/pause") makes things worse rather than better: completing the reference balance drops the freed node's refcount to zero a second time, giving a second `bdrv_delete()` on an already-deleted node — `QTAILQ_REMOVE` on NULLed links, then a double `g_free()`. On a host where a coalesce fails at that last step, that is a deterministic SIGSEGV or a glibc double-free abort instead of a leak.

## The commits

1. **`libqcow2: keep a job-lifetime reference on the commit filter node`** — the root-cause fix. `commit_start()` dropped the creation reference right after `bdrv_append()`, leaving the node alive only through its parent links; the job itself holds no reference on it (`block_job_create()` is called on `bs`, and the `block_job_add_bdrv()` loop starts at `top`). Keep that reference for the job's lifetime and release it in `commit_clean()` — and in the `commit_start()` failure path, since `job_early_fail()` does not run `.clean`. The node is now valid in `commit_abort()` on **every** path, including the two where `bdrv_drop_intermediate()` fails *without* freeing it (`exit_wrlock`, and `bdrv_replace_node_common()` failure) and the filter is still spliced into the chain. With the node guaranteed alive, the missing unrefs in the `!backing` path are added and are now correct rather than a double-delete.

2. **`block-qcow2: fix lost wakeups in the commit, query and cancel handshake`** — the three control operations published their request to `s->inflight` and only then took `commit_lock` to wait. The qcow2 thread does not need our bottom-half kick to run: it is already awake whenever a data request armed it, and `qcow2_handle_requests()` drops `s->lock` between iterations. It can therefore run the handler and signal before the caller reaches `pthread_cond_wait()`. The wakeup is lost, there is no predicate to recover, and the **tapdisk main thread blocks forever** — no scheduler iteration, no ring polling, no control socket. The VBD is dead and only SIGKILL clears it. The trigger window is the normal usage pattern, since sm polls commit progress while the guest is doing I/O. Fixed with a per-request `done` predicate set under `commit_lock`, a wait loop, and broadcast.

3. **`block-qcow2: make the open and close paths safe against the qcow2 thread`** — `_qcow2_close()` released `s->lock` before kicking the bottom half, so the thread could observe `driver_opened == false`, delete the bottom half and finalize the AioContext before the kick landed (write-after-free into the `QEMUBH`, notify on a destroyed event notifier). Close also dismissed the commit job without cancelling it: `job_dismiss_locked()` only accepts a concluded job, so for a live job it just logged `job dismiss error` and tore the `BlockBackend` and AioContext down underneath it. It also left the job behind in the process-global job list, so after a pause and unpause the next commit found a stale job holding freed nodes. The cancel now covers `RUNNING`/`PAUSED`/`READY`/`STANDBY` rather than only `RUNNING`/`READY`, so a paused job is no longer silently left running while the caller tears everything down. The remaining states are deliberately **not** cancelled — the commit message explains why, and this is not a detail to "fix" later by widening the set again — but they now return `-EBUSY` rather than success, so the storage manager is not told a coalesce was cancelled while it is in fact finalizing. Note this covers the finalization states only: soft-cancelling a *leaf* coalesce that reached `READY` still completes it and reports success, which is a pre-existing behaviour recorded as a known gap in #16. `_qcow2_open()` waited without a predicate, so a spurious wakeup returned success with the device published at size 0 and the first request calling `qemu_bh_schedule(NULL)`. And a failed open never joined the thread, so tapdisk's immediate retry re-initialized the QEMU globals (BQL, main loop, AIO context, signalfd) while the previous thread was still destroying them, leaking a joinable thread each time.

## Review history

The branch was reviewed three times by independent passes that were not shown each other's conclusions: a reference-count/lifetime audit of `commit.c`, a concurrency/memory-safety audit of `block-qcow2.c`, and an adversarial pass whose brief was to falsify the claims above.

**Confirmed.** The lifetime audit independently re-derived the free-inside-`commit_prepare()` mechanism (including the load-bearing detail that `bdrv_graph_wrunlock()` ends with an `aio_bh_poll()`, so the deferred parent unrefs fire synchronously), walked the ledger across all seven paths, and returned "correct as written, no correction required" — no leak, no double-unref, nothing freed while referenced. It also verified that the extended liveness window is harmless: the merged-away image's open window is *not* extended, because it is pinned by the job's own `BdrvChild` edges until `block_job_remove_all_bdrv()`, which runs after `commit_clean()` in both the old and new code. What lives a little longer is only the filter node itself — an in-memory node with no file, no fd, no LV, and `nperm=0 / nshared=BLK_PERM_ALL`. The adversarial pass could not break the claim either.

The lost-wakeup fix and the bottom-half ordering were confirmed by both other passes. **No deadlock** results from the new `commit_lock → s->lock` nesting: every acquisition site in the file was enumerated, and the reverse order occurs nowhere, because `qcow2_handle_requests()` releases `s->lock` before dispatching and no handler takes `commit_lock` while holding it.

**Broken, and corrected before this was opened.** An earlier version widened the cancel to every job state but `UNDEFINED`/`NULL`. Two passes independently showed that is a regression — worth recording here, because the narrow state set that shipped instead looks like an oversight until you know why it is narrow.

The job is created with auto-finalize, so `CREATED`, `WAITING`, `PENDING` and `ABORTING` only exist while `commit_start()` or the finalization sequence is on the stack — and the cancel handler is reachable from the nested `aio_bh_poll()` that `bdrv_graph_wrunlock()` performs inside them. Cancelling from there re-enters `job_finalize_single_locked()` on a job that is already being finalized, and the outer finalize then transitions `CONCLUDED → ABORTING`, which `JobSTT` asserts on. In `CREATED` the job has no `s->top` yet, so `commit_abort()` dereferences a NULL `BlockBackend`. Hence `RUNNING`/`PAUSED`/`READY`/`STANDBY` only: the states where the job is started and stays alive on its own, which is what the close path actually needs.

## Verification status

- **Every commit in the series compiles cleanly** — both files, under the project's own flags (`-Wall -Werror`, per `drivers/Makefile.am`), against real Xen headers. Verified per-commit, not just at the tip, so the series is bisectable.
- **Nothing has been run.** No unit tests (there is no qcow2 coverage in `mockatests/`), no functional testing, no host. Please build it properly, and exercise a coalesce / pause / cancel matrix before this goes near a release.
- Suggested minimum: fault-injection on the header rewrite (the reported failure); `tap-ctl cancel` under sustained guest I/O, several hundred iterations (the lost-wakeup race); VM shutdown during both an intermediate and a leaf coalesce; a failed-open retry loop watching the thread count; and a deep-chain soak watching node and fd counts.

Suggested targeted test for the root cause, which reproduces both the original crash and the `9.3` regression deterministically: force the backing-file header rewrite to fail *after* the parent switch has succeeded — open the overlay read-only so `bdrv_reopen_set_read_only()` fails, or inject `EIO`/`ENOSPC` on the header write, or use a backing path longer than 1023 characters — then run a commit on an intermediate node. Expected: a `0044`-only build survives while leaking a reference on `top` (the image stays open); a `0045` build crashes in `bdrv_delete`/`QTAILQ_REMOVE` or aborts on a double free; this branch completes cleanly.

## Second review round

After the first version of this branch was pushed, it was reviewed again by four independent passes (refcount/lifetime, concurrency, maintainer-perspective, red-team) plus a dedicated compile check. That round found the following, all fixed in what is now proposed:

- **The series was not bisectable.** The widened cancel condition sat in the lost-wakeup commit and was narrowed again in the next one, so at that revision the tree segfaulted on a job in `CREATED`. The history has been rebuilt so no revision is worse than the base.
- **The cancel reported success for jobs it did not cancel.** The states that are deliberately skipped now return `-EBUSY` instead of 0, so the storage manager is never told a coalesce was cancelled while it is in fact completing.
- **`force`-cancel at close was dropped.** It was added on the strength of a "graceful cancel blocks indefinitely" argument that a later review disproved (the queue is quiesced before close, and the close waits on `blk_drain_all()` regardless), and it discarded a leaf coalesce that the storage manager had already told to complete. The pre-existing graceful cancel is kept; the thread-exit path still force-cancels, since that is the last chance to stop a job before everything it references is destroyed.
- The vendored `commit.c` change no longer rides along in a driver commit, an incorrect rationale in a comment was fixed, and several overstated claims were removed from the commit messages.

Two findings from that round are **deliberately left for separate changes**, both listed below.

## Not addressed here

Deliberately out of scope, each needing its own review:

- The mirror-job abort paths used by **leaf coalesce** (`commit_active_start` → `mirror.c`), which contain the same unguarded `->backing->bs` shape.
- Three of the five `qemu_bh_schedule()` sites still kick outside `s->lock` (harmless today — only the close path races teardown), `s->inflight` is not drained at thread exit, and `s->bh` is not NULLed after deletion.
- `do_commit()` reports success for a commit that never started ("top doesn't exist", "no base to commit in").
- The blktap ring `munmap` race, the NBD client use-after-free and fd reuse, and the unlocked `vbd->images` surgery from the qcow2 thread. These share one proper fix — marshal completions back to the tapdisk main thread over an eventfd rather than running tapdisk callbacks on the qcow2 thread — which is a design change, not a patch.
- **`td_query` cannot report a failed coalesce** — see the callout at the top of this description. This is the one item that should block shipping the series on its own.
- A pre-existing bug in adjacent code: `do_commit()` returns success when it started no job at all (top image not found, or no base to commit into), after which every query reports `undefined` forever. One line each, but it changes what sm sees, so it belongs in the same conversation as the item above.

## Packaging

The vendored patch stack in `xcp-ng-rpms/blktap` needs a companion change: this rewrites the hunk that `0044-libqcow2-fix-abort-commit-without-crash.patch` introduces, and it supersedes the `3.55.5-9.3` fixup entirely. Both must be dropped or regenerated, atomically with this.

## One thing for the sm side

`bdrv_drop_intermediate()`'s partial-failure case reports failure for a coalesce that **did** happen at the graph level: the chain is already re-pointed, only the on-disk header rewrite failed. sm must therefore not assume a failed `qcow2_commit` means the chain is untouched. This is the `FIXME` at `commit.c:62` and it needs a decision on the sm side independently of this branch.
