### PR TITLE
tapdisk: report the commit job result in the query response (so a failed coalesce is visible to sm)

### DIFF
--- a/control/tap-ctl-commit.c
+++ b/control/tap-ctl-commit.c
@@ -34,6 +34,7 @@
 
 #include <stdio.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
@@ -90,7 +91,14 @@ tap_ctl_query_commit_job(const int id, const int minor)
 		return err;
 
 	if (message.type == TAPDISK_MESSAGE_QUERY_COMMIT_JOB_RSP) {
-		printf("Commit status '%s' (%lu/%lu)\n", message.u.query.status, message.u.query.current_progress, message.u.query.total_progress);
+		/*
+		 * The job result is a negative errno, or zero, and is appended
+		 * after the existing fields so that readers matching the old
+		 * format keep working unchanged.
+		 */
+		printf("Commit status '%s' (%lu/%lu) error %"PRId32"\n",
+		       message.u.query.status, message.u.query.current_progress,
+		       message.u.query.total_progress, message.u.query.job_error);
 		err = 0;
 	} else if (message.type == TAPDISK_MESSAGE_ERROR) {
 		err = -message.u.response.error;

--- a/drivers/block-qcow2.c
+++ b/drivers/block-qcow2.c
@@ -170,6 +170,7 @@ struct qcow2_state {
 	pthread_mutex_t           lock;
 	pthread_cond_t            cond;
 	bool                      driver_opened;
+	bool                      open_done;
 	int                       open_status;
 	MemReentrancyGuard        mem_reentrancy_guard;
 
@@ -435,6 +436,7 @@ qcow2_open(void *opaque)
 
 	pthread_mutex_lock(&s->lock);
 	s->open_status = 0;
+	s->open_done = true;
 	pthread_cond_signal(&s->cond);
 
 	while (s->driver_opened) {
@@ -444,8 +446,42 @@ qcow2_open(void *opaque)
 	}
 	pthread_mutex_unlock(&s->lock);
 
+	/*
+	 * Nothing must outlive this thread: the BlockBackend, the AioContext and
+	 * the driver state are all torn down below. A job that is still live
+	 * here would keep references to them, so cancel it before dismissing it.
+	 * job_dismiss_locked() only accepts a concluded job, which is why it used
+	 * to fail with "job dismiss error" and leave the job behind.
+	 */
 	job_lock();
 	BlockJob *bjob = block_job_get_locked(COMMIT_JOB_ID);
+	if (bjob) {
+		/*
+		 * Same restriction as do_cancel_commit_job(): only the states
+		 * where the job is started and stays alive on its own. The
+		 * transient finalization states cannot be observed here, because
+		 * the job is created with auto_finalize and this code runs with
+		 * an empty stack, not from the nested poll inside a finalize.
+		 * Force-cancel: this is the last chance to stop the job before
+		 * everything it references is destroyed below.
+		 */
+		switch (bjob->job.status) {
+		case JOB_STATUS_RUNNING:
+		case JOB_STATUS_PAUSED:
+		case JOB_STATUS_READY:
+		case JOB_STATUS_STANDBY: {
+			int cancel_err = job_cancel_sync_locked(&bjob->job, true);
+			if (cancel_err && cancel_err != -ECANCELED)
+				DPRINTF("Qcow2: job cancel error at close: %d\n", cancel_err);
+			break;
+		}
+		default:
+			break;
+		}
+
+		/* The cancel may have dismissed and freed the job already. */
+		bjob = block_job_get_locked(COMMIT_JOB_ID);
+	}
 	if (bjob) {
 		Job *job = &bjob->job;
 		job_dismiss_locked(&job, &local_err);
@@ -482,6 +518,7 @@ qcow2_open(void *opaque)
 
 	pthread_mutex_lock(&s->lock);
 	s->open_status = -EINVAL;
+	s->open_done = true;
 	pthread_cond_signal(&s->cond);
 	pthread_mutex_unlock(&s->lock);
 
@@ -527,11 +564,27 @@ _qcow2_open(td_driver_t *driver, const char *name,
 	qemu_thread_create(&s->thread, "td-qcow2", qcow2_open, s,
 			   QEMU_THREAD_JOINABLE);
 
-	pthread_cond_wait(&s->cond, &s->lock);
+	while (!s->open_done)
+		pthread_cond_wait(&s->cond, &s->lock);
 	err = s->open_status;
 	s->open_status = 0;
 	pthread_mutex_unlock(&s->lock);
 
+	if (err) {
+		/*
+		 * The thread tears the QEMU globals down (main loop, BQL, CPU
+		 * loop) on its way out. tapdisk frees the driver state and
+		 * retries the open right away, so wait for it to be gone before
+		 * returning: otherwise the next attempt re-initializes those
+		 * globals while this thread is still destroying them.
+		 */
+		qemu_thread_join(&s->thread);
+
+		pthread_cond_destroy(&s->commit_cond);
+		pthread_mutex_destroy(&s->commit_lock);
+		pthread_cond_destroy(&s->cond);
+		pthread_mutex_destroy(&s->lock);
+	}
 
 	return err;
 }
@@ -546,11 +599,19 @@ _qcow2_close(td_driver_t *driver)
 
 	DBG(TLOG_WARN, "qcow2_close\n");
 
+	/*
+	 * Kick the thread while still holding the lock. The thread can only
+	 * observe driver_opened == false with s->lock held, hence only once this
+	 * has released it, so the bottom half is guaranteed to still exist when
+	 * it is scheduled here. Kicking after the unlock instead leaves a window
+	 * where the thread has already left its loop, deleted the bottom half
+	 * and finalized the AioContext, and the kick writes into freed memory
+	 * and notifies a destroyed event notifier.
+	 */
 	pthread_mutex_lock(&s->lock);
 	s->driver_opened = false;
-	pthread_mutex_unlock(&s->lock);
-
 	qemu_bh_schedule(s->bh);
+	pthread_mutex_unlock(&s->lock);
 
 	// Ignore return, qcow2_open() always return NULL; or will abort
 	qemu_thread_join(&s->thread);
@@ -1155,13 +1216,52 @@ do_cancel_commit_job(struct qcow2_state *s, struct qcow2_request *req)
 		goto signal;
 	}
 
-	if (bjob->job.status == JOB_STATUS_RUNNING ||
-		bjob->job.status == JOB_STATUS_READY) {
+	/*
+	 * Cancel the job in every state where it is started and can stay alive
+	 * on its own. Restricting this to RUNNING and READY made the cancel a
+	 * silent no-op that still reported success for a paused or standby job,
+	 * and the caller (typically _qcow2_close()) then tore the BlockBackend
+	 * and the AioContext down underneath it.
+	 *
+	 * CREATED, WAITING, PENDING and ABORTING are deliberately excluded even
+	 * though the verb table allows some of them. The job is created with
+	 * auto_finalize, so those states only exist while commit_start() or the
+	 * finalization sequence is on the stack, and this handler can be reached
+	 * from the nested aio_bh_poll() that bdrv_graph_wrunlock() performs
+	 * inside them. Cancelling there re-enters job_finalize_single_locked()
+	 * on a job that is already being finalized: the job state machine
+	 * asserts, the transaction is unreferenced twice, and commit_abort()
+	 * runs on half-initialized or already-cleaned job state.
+	 */
+	switch (bjob->job.status) {
+	case JOB_STATUS_RUNNING:
+	case JOB_STATUS_PAUSED:
+	case JOB_STATUS_READY:
+	case JOB_STATUS_STANDBY:
 		if (req->sync == false) {
 			job_cancel_locked(&bjob->job, false);
 		} else {
+			/*
+			 * The job may be dismissed and freed by the cancel, so
+			 * bjob must not be used afterwards.
+			 */
 			err = job_cancel_sync_locked(&bjob->job, false);
 		}
+		break;
+	case JOB_STATUS_CONCLUDED:
+		/* Already finished, nothing left to cancel. */
+		DPRINTF("Qcow2: job already concluded.\n");
+		break;
+	default:
+		/*
+		 * Mid-finalization. Do not report this as a successful cancel:
+		 * the job is about to complete, and telling the caller it was
+		 * cancelled would have it believe the chain was left alone.
+		 */
+		DPRINTF("Qcow2: not cancelling job in state '%s'.\n",
+			JobStatus_str(bjob->job.status));
+		err = -EBUSY;
+		break;
 	}
 	job_unlock();
 

--- a/drivers/block-qcow2.c
+++ b/drivers/block-qcow2.c
@@ -179,6 +179,10 @@ struct qcow2_state {
 	pthread_mutex_t           commit_lock;
 	pthread_cond_t            commit_cond;
 	JobInfo                   job_info;
+	/* Result of the commit job, valid once it has concluded */
+	int                       job_ret;
+	/* The job concluded and was dismissed; job_info/job_ret are its outcome */
+	bool                      job_reaped;
 
 	/* Stats */
 	uint64_t                  queued;
@@ -1020,6 +1024,19 @@ do_commit(struct qcow2_state *s, struct qcow2_request *req)
 	BlockDriverState *bs, *top_bs, *base_bs;
 	int err = 0;
 
+	/*
+	 * A new commit invalidates the result kept from the previous one, even
+	 * if this one turns out not to start a job at all: reporting the old
+	 * error against a new request would be worse than reporting nothing.
+	 */
+	pthread_mutex_lock(&s->commit_lock);
+	s->job_ret = 0;
+	s->job_reaped = false;
+	s->job_info.status = JOB_STATUS_UNDEFINED;
+	s->job_info.current_progress = 0;
+	s->job_info.total_progress = 0;
+	pthread_mutex_unlock(&s->commit_lock);
+
 	bs = blk_bs(s->conf.blk);
 	node = bs->node_name;
 	if (strcmp(bs->filename, req->top) == 0) {
@@ -1092,6 +1109,7 @@ qcow2_query_commit_job(td_driver_t *driver, td_query_t *query)
 		query->status = JobStatus_str(s->job_info.status);
 		query->current_progress = s->job_info.current_progress;
 		query->total_progress = s->job_info.total_progress;
+		query->job_error = s->job_ret;
 	}
 
 	err = req->error;
@@ -1112,6 +1130,8 @@ do_query_commit_job(struct qcow2_state *s, struct qcow2_request *req)
 	BlockJob *bjob;
 	JobStatus status = JOB_STATUS_UNDEFINED;
 	uint64_t current = 0, total = 0;
+	int job_ret = 0;
+	bool have_job = false;
 
 	job_lock();
 	bjob = block_job_get_locked(COMMIT_JOB_ID);
@@ -1120,10 +1140,19 @@ do_query_commit_job(struct qcow2_state *s, struct qcow2_request *req)
 		DPRINTF("Qcow2: no job running.\n");
 		goto signal;
 	}
+	have_job = true;
 
 	status  = bjob->job.status;
 	current = bjob->job.progress.current;
 	total   = bjob->job.progress.total;
+	/*
+	 * The result of the job, not of this query. It is only meaningful once
+	 * the job reached CONCLUDED, and it is the only way for the caller to
+	 * tell a coalesce that finished from one that aborted: both end up
+	 * concluded, and an aborted commit can even report full progress since
+	 * the data copy itself did complete.
+	 */
+	job_ret = bjob->job.ret;
 
 	if (status == JOB_STATUS_READY) {
 		Job *job = &bjob->job;
@@ -1149,9 +1178,33 @@ do_query_commit_job(struct qcow2_state *s, struct qcow2_request *req)
 
 signal:
 	pthread_mutex_lock(&s->commit_lock);
-	s->job_info.status = status;
-	s->job_info.current_progress = current;
-	s->job_info.total_progress = total;
+	if (have_job) {
+		s->job_info.status = status;
+		s->job_info.current_progress = current;
+		s->job_info.total_progress = total;
+		s->job_ret = job_ret;
+		/*
+		 * A concluded job is dismissed by the query that observes it,
+		 * so it is gone from the next query onwards. Remember the whole
+		 * outcome, not just the result: reporting the result next to a
+		 * status of undefined would be useless, because a caller is told
+		 * to read the result only once the status says concluded.
+		 */
+		if (status == JOB_STATUS_CONCLUDED)
+			s->job_reaped = true;
+	} else if (!s->job_reaped) {
+		s->job_info.status = status;
+		s->job_info.current_progress = current;
+		s->job_info.total_progress = total;
+		s->job_ret = job_ret;
+	}
+	/*
+	 * Otherwise keep what the last job ended with, so that a lost or
+	 * duplicated query cannot turn a failed coalesce into a successful
+	 * looking one. It is cleared when the next commit starts, and it does
+	 * not outlive the driver: a pause closes and reopens it, which resets
+	 * this along with everything else.
+	 */
 
 	req->error = err;
 	req->done  = true;

--- a/drivers/block-qcow2.c
+++ b/drivers/block-qcow2.c
@@ -110,6 +110,11 @@ struct qcow2_request;
 
 struct qcow2_request {
 	int                     error;
+	/*
+	 * Predicate for the control operations (commit, query, cancel): set by
+	 * the qcow2 thread under commit_lock once error/job_info are valid.
+	 */
+	bool                    done;
 	enum qcow2_ops          op;
 	union {
 		/* OP_READ, OP_WRITE */
@@ -527,6 +532,7 @@ _qcow2_open(td_driver_t *driver, const char *name,
 	s->open_status = 0;
 	pthread_mutex_unlock(&s->lock);
 
+
 	return err;
 }
 
@@ -916,15 +922,26 @@ qcow2_commit(td_driver_t *driver, const char *name)
 
 	req->top   = strdup(name);
 	req->op    = QCOW2_OP_COMMIT;
+	req->error = 0;
+	req->done  = false;
+
+	/*
+	 * Lock order is commit_lock -> lock, and never the reverse: the qcow2
+	 * thread releases lock before dispatching a request, so no handler takes
+	 * commit_lock while holding lock. Holding commit_lock across the publish
+	 * is belt and braces on top of the done predicate below; the predicate
+	 * alone would already stop the wakeup from being lost.
+	 */
+	pthread_mutex_lock(&s->commit_lock);
 
 	pthread_mutex_lock(&s->lock);
 	QSIMPLEQ_INSERT_TAIL(&s->inflight, req, list);
 	pthread_mutex_unlock(&s->lock);
 
-	pthread_mutex_lock(&s->commit_lock);
 	qemu_bh_schedule(s->bh);
 
-	pthread_cond_wait(&s->commit_cond, &s->commit_lock);
+	while (!req->done)
+		pthread_cond_wait(&s->commit_cond, &s->commit_lock);
 	err = req->error;
 	pthread_mutex_unlock(&s->commit_lock);
 
@@ -977,7 +994,8 @@ do_commit(struct qcow2_state *s, struct qcow2_request *req)
 signal_commit:
 	pthread_mutex_lock(&s->commit_lock);
 	req->error = err;
-	pthread_cond_signal(&s->commit_cond);
+	req->done  = true;
+	pthread_cond_broadcast(&s->commit_cond);
 	pthread_mutex_unlock(&s->commit_lock);
 }
 
@@ -995,15 +1013,19 @@ qcow2_query_commit_job(td_driver_t *driver, td_query_t *query)
 		return -EBUSY;
 
 	req->op    = QCOW2_OP_QUERY;
+	req->error = 0;
+	req->done  = false;
+
+	pthread_mutex_lock(&s->commit_lock);
 
 	pthread_mutex_lock(&s->lock);
 	QSIMPLEQ_INSERT_TAIL(&s->inflight, req, list);
 	pthread_mutex_unlock(&s->lock);
 
-	pthread_mutex_lock(&s->commit_lock);
 	qemu_bh_schedule(s->bh);
 
-	pthread_cond_wait(&s->commit_cond, &s->commit_lock);
+	while (!req->done)
+		pthread_cond_wait(&s->commit_cond, &s->commit_lock);
 
 	if (query) {
 		query->status = JobStatus_str(s->job_info.status);
@@ -1071,12 +1093,13 @@ signal:
 	s->job_info.total_progress = total;
 
 	req->error = err;
-	pthread_cond_signal(&s->commit_cond);
+	req->done  = true;
+	pthread_cond_broadcast(&s->commit_cond);
 	pthread_mutex_unlock(&s->commit_lock);
 }
 
 
-int
+static int
 qcow2_cancel_commit_job(td_driver_t *driver, bool wait)
 {
 	struct qcow2_state *s = (struct qcow2_state *)driver->data;
@@ -1089,17 +1112,21 @@ qcow2_cancel_commit_job(td_driver_t *driver, bool wait)
 	if (!req)
 		return -EBUSY;
 
-	req->op   = QCOW2_OP_CANCEL_COMMIT;
-	req->sync = wait;
+	req->op    = QCOW2_OP_CANCEL_COMMIT;
+	req->sync  = wait;
+	req->error = 0;
+	req->done  = false;
+
+	pthread_mutex_lock(&s->commit_lock);
 
 	pthread_mutex_lock(&s->lock);
 	QSIMPLEQ_INSERT_TAIL(&s->inflight, req, list);
 	pthread_mutex_unlock(&s->lock);
 
-	pthread_mutex_lock(&s->commit_lock);
 	qemu_bh_schedule(s->bh);
 
-	pthread_cond_wait(&s->commit_cond, &s->commit_lock);
+	while (!req->done)
+		pthread_cond_wait(&s->commit_cond, &s->commit_lock);
 	err = req->error;
 	pthread_mutex_unlock(&s->commit_lock);
 
@@ -1143,7 +1170,8 @@ do_cancel_commit_job(struct qcow2_state *s, struct qcow2_request *req)
 signal:
 	pthread_mutex_lock(&s->commit_lock);
 	req->error = err;
-	pthread_cond_signal(&s->commit_cond);
+	req->done  = true;
+	pthread_cond_broadcast(&s->commit_cond);
 	pthread_mutex_unlock(&s->commit_lock);
 }
 

--- a/drivers/tapdisk-control.c
+++ b/drivers/tapdisk-control.c
@@ -1369,7 +1369,7 @@ tapdisk_control_query_commit_job(struct tapdisk_ctl_conn *conn,
 {
 	int err;
 	td_vbd_t *vbd;
-	td_query_t query;
+	td_query_t query = { 0 };
 
 	ASSERT(conn);
 	ASSERT(request);
@@ -1397,6 +1397,7 @@ out:
 				sizeof(response->u.query.status));
 		response->u.query.current_progress = query.current_progress;
 		response->u.query.total_progress = query.total_progress;
+		response->u.query.job_error = query.job_error;
 	}
 	return td_err_set_errno(error, err);
 }

--- a/drivers/tapdisk.h
+++ b/drivers/tapdisk.h
@@ -216,6 +216,13 @@ struct td_query {
         uint64_t                    current_progress;
         uint64_t                    total_progress;
         const char                  *status;
+        /*
+         * Result of the job itself, as opposed to the result of the query.
+         * Meaningful once the status says the job concluded, which keeps
+         * being reported after the job has been reaped, until another one is
+         * started. Zero when it succeeded, and when no job has run.
+         */
+        int                         job_error;
 };
 
 /* 

--- a/include/tapdisk-message.h
+++ b/include/tapdisk-message.h
@@ -118,6 +118,14 @@ struct tapdisk_message_query {
 	uint64_t                         current_progress;
 	uint64_t                         total_progress;
 	char                             status[TAPDISK_MESSAGE_STRING_LENGTH];
+	/*
+	 * Result of the commit job, valid once its status says concluded. Zero
+	 * when it succeeded, and when no job has run. Appended at the end of
+	 * the structure on purpose: the enclosing union is larger than this
+	 * member, so the on-the-wire message size does not change, which the
+	 * assertion below enforces.
+	 */
+	int32_t                          job_error;
 };
 
 /**
@@ -211,6 +219,18 @@ struct tapdisk_message {
 		tapdisk_message_query_t    query;
 	} u;
 };
+
+/*
+ * The control message is exchanged as a fixed number of bytes and there is no
+ * version negotiation, so growing the largest member of the union silently
+ * breaks every tapdisk and tap-ctl that was built against another revision.
+ * Adding fields to a smaller member, as the query response does, is safe only
+ * for as long as it stays smaller.
+ */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+_Static_assert(sizeof(tapdisk_message_query_t) <= sizeof(tapdisk_message_params_t),
+	       "the query response must not grow the control message");
+#endif
 
 enum tapdisk_message_id {
 	TAPDISK_MESSAGE_ERROR = 1,

--- a/qcow2/lib/block/commit.c
+++ b/qcow2/lib/block/commit.c
@@ -99,8 +99,13 @@ static void commit_abort(Job *job)
      * something to base, the intermediate images aren't valid any more. */
     bdrv_graph_rdlock_main_loop();
     if (!s->commit_top_bs->backing) {
+        /*
+         * Defensive only: a live node never loses its backing child, and the
+         * reference taken in commit_start() keeps this one alive. If this ever
+         * fires, the lifetime assumption above is wrong.
+         */
         bdrv_graph_rdunlock_main_loop();
-        return;
+        goto cleanup;
     }
     commit_top_backing_bs = s->commit_top_bs->backing->bs;
     bdrv_graph_rdunlock_main_loop();
@@ -111,6 +116,7 @@ static void commit_abort(Job *job)
     bdrv_graph_wrunlock();
     bdrv_drained_end(commit_top_backing_bs);
 
+cleanup:
     bdrv_unref(s->commit_top_bs);
     bdrv_unref(top_bs);
 }
@@ -128,6 +134,19 @@ static void commit_clean(Job *job)
 
     g_free(s->backing_file_str);
     blk_unref(s->top);
+
+    /*
+     * Release the reference taken in commit_start(). On the success path the
+     * filter node is already detached from its parents, so this is the last
+     * reference to it. Clear the pointer before dropping the reference: the
+     * deletion polls the event loop, and nothing reached from there must find
+     * s->commit_top_bs pointing at a node that is midway through being freed.
+     */
+    if (s->commit_top_bs) {
+        BlockDriverState *commit_top_bs = s->commit_top_bs;
+        s->commit_top_bs = NULL;
+        bdrv_unref(commit_top_bs);
+    }
 }
 
 static int coroutine_fn commit_run(Job *job, Error **errp)
@@ -330,12 +349,19 @@ void commit_start(const char *job_id, BlockDriverState *bs,
     commit_top_bs->total_sectors = top->total_sectors;
 
     ret = bdrv_append(commit_top_bs, top, errp);
-    bdrv_unref(commit_top_bs); /* referenced by new parents or failed */
     if (ret < 0) {
+        bdrv_unref(commit_top_bs);
         commit_top_bs = NULL;
         goto fail;
     }
 
+    /*
+     * Keep the creation reference for the whole lifetime of the job instead of
+     * relying on the parent links alone: bdrv_drop_intermediate() moves those
+     * parents to base and then drops the last reference, which deletes the
+     * node while s->commit_top_bs still points at it. commit_abort() would
+     * then run on freed memory. The reference is released in commit_clean().
+     */
     s->commit_top_bs = commit_top_bs;
 
     /*
@@ -446,6 +472,11 @@ fail:
         bdrv_replace_node(commit_top_bs, top, &error_abort);
         bdrv_graph_wrunlock();
         bdrv_drained_end(top);
+        /*
+         * commit_clean() does not run for a job that failed to start, so the
+         * reference kept for the job lifetime is released here.
+         */
+        bdrv_unref(commit_top_bs);
     }
 }
 


### PR DESCRIPTION
**Draft — compiles, never run. Stacked on #15: this branch contains that series plus one commit, so review only the top commit (`tapdisk: report the commit job result in the query response`).**

## Why

A coalesce that fails is indistinguishable from one that succeeds.

`tap-ctl query` returns the job's *status* and *progress*, never the result of the job. Every commit job ends in the same `concluded` state whether it completed or aborted — and an aborted commit can report **full progress**, because the data copy does finish. What fails is the step after it: rewriting the overlay's backing-file header, which is where an out-of-space or I/O error lands.

That is not a theoretical gap. This is sm's polling loop today, in `QCow2Util.coalesceOnline()` (`drivers/qcow2util.py`, `3.2.12-8.3-devel`):

```python
while status != "concluded":
    time.sleep(1)
    status, nb, _ = TapCtl.query(pid, minor, quiet=True)
return nb
```

It waits for `concluded` and returns the byte count as the success value. There is no error check, and `TapCtl.query()` parses only `Commit status '<status>' (<n>/<total>)`, so there is nothing to check even if it wanted to.

**What that costs, precisely.** sm is not left with dangling children. `cleanup.py` compares each child's real on-disk parent against the expected one (`real_parent_uuid == vdi.parent.uuid`): children that match are recorded as already relinked by tapdisk and skipped, and the rest go through the normal relink, which rewrites their backing pointers. After a failed coalesce that means sm relinks the children itself, believing the coalesce worked — so it **re-points them at a base image that may only be partially populated** (when the failure happened during the copy rather than at the header rewrite), rewrites the backing file of an image that may be open by a tapdisk on another host, and then deletes the coalesced VDI unconditionally. The failure is never reported.

Until now that failure normally crashed tapdisk — the use-after-free fixed by #15 — which made it visible. With that crash fixed and no error reported, the same failure becomes silent, and we would have traded a loud bug for a quiet one.

## Field evidence

The chain damage this is meant to prevent is not hypothetical: on one affected host, `Parent of QCOW2-… wasn't found during scan` appears **36 times**, the VDI can no longer be activated, and the customer's VM clone fails with `SR_BACKEND_FAILURE_46`.

Worth calibrating expectations, though: across 21 bug reports from that provider, the *most common* coalesce failure is not a silently-failed commit — it is sm **refusing to start** one (`Multiple openers`), on both builds. This PR does not address that, and it is what most of those end customers are actually hitting.

## What this does

Carries the job's result alongside the status and progress:

- `struct td_query` gains `job_error`, filled by the qcow2 driver from `job->ret` at the same point it reads the status and progress, under the same lock.
- `struct tapdisk_message_query` gains `job_error`, **appended at the end**.
- `tap-ctl query` prints it after the existing fields: `Commit status 'concluded' (100/100) error -28`.

Zero means the job succeeded, or that no job has run. It is meaningful once the status says `concluded` — and that status keeps being reported, together with the result and the progress, after the job has been reaped, until another commit starts. Otherwise a single lost or duplicated query would turn a failed coalesce back into a successful looking one, since the query that observes a concluded job is also the one that dismisses it.

## Compatibility

Both aspects are deliberate and were verified rather than assumed:

- **Wire format is unchanged.** `sizeof(tapdisk_message_t)` is 544 bytes before and after — the enclosing union is dominated by a larger member, so growing the query member from 272 to 280 bytes changes nothing on the wire. Checked by compiling the header both ways and printing the sizes.
- **Existing parsers keep working.** The value is printed *after* the existing fields, so sm's current regex — `re.match(r"Commit status '(.+)' \((\d+)\/(\d+)\)", output)`, unanchored at the end — still matches unchanged. Nothing breaks the moment this ships; readers opt in when they want the result.

## The sm side, and the order things must ship in

This is only half the fix. A companion sm change is needed to parse the field and fail the coalesce when it is non-zero, instead of inferring success from `concluded` plus progress. I will open that as a separate draft against `3.2.12-8.3-devel` once the format here is agreed.

**blktap first, sm second — and the sm side must tolerate old blktap.** sm and blktap are separate RPMs, and the coalesce runs on whichever host holds the attached leaf, so mixed versions within a pool are normal rather than exceptional. `TapCtl.query()` does `re.match(...)` and then `m.group(1)` with **no `None` guard**, so if the sm-side regex is tightened to *require* the new ` error <n>` field, a host still running old blktap produces `m is None` → `AttributeError`, which is not a `TapCtl.CommandFailure` and therefore is not caught — failing **every** coalesce on that host. The sm change must make the new group optional and default it to 0, and add the missing `None` guard.

**`-EBUSY` from cancel is new, and overloaded.** #15 makes a cancel arriving during finalization return `-EBUSY` instead of a bogus success. sm turns any non-zero into `CommandFailure` and `commit_cancel` reports `"False"`, with no retry — so a transient few-hundred-microsecond window now reports "cancel failed" for a coalesce that is about to complete successfully. The same errno already means "request pool exhausted" elsewhere in the driver, so sm cannot distinguish them. Worth deciding whether sm should retry on `-EBUSY`.

**Cancellation will now be reported as an error.** `job_update_rc_locked()` sets `-ECANCELED` on any cancelled job, so a routine GC abort — clearing the `gc_running` file, which triggers `TapCtl.cancel_commit` — leaves the job concluded with `error -125`. If the sm side naively treats non-zero as failure, ordinary aborts become logged coalesce failures. `-ECANCELED` needs to be handled explicitly as "abandoned, chain untouched", not as an error.

Worth flagging for release notes: once both sides land, **coalesces that currently appear to succeed will start reporting failure**. That is correct — they were already failing — but it will look like a new bug to whoever watches the GC logs.

## Packaging

Nothing beyond #15's requirement: this branch touches no vendored QEMU code, but it contains #15, so the same instruction applies — `0044-libqcow2-fix-abort-commit-without-crash.patch` and the `3.55.5-9.3` fixup must be dropped or regenerated with it. Note 0044's content is also already a commit on the branch base (`09a1a26`), which `22fa5ae` rewrites, so dropping the patch file and dropping the commit are different actions and the spec should be checked for which it applies.

## Verification

- The three touched `.c` files compile clean under their directory's real flags (`-Wall -Werror` for `drivers/`, plus `-DTAPCTL` and friends for `control/`), against real Xen headers. The other two touched files are headers, exercised through those compiles.
- Message sizes compared before/after, as above.
- **Nothing has been run.** The behaviour to test is the one this exists for: make the header rewrite fail mid-coalesce (fill the SR, or make the parent read-only) and confirm `tap-ctl query` reports a non-zero error where it previously reported a clean `concluded`.

## Review, and what the second commit fixes

Three independent passes reviewed the first commit: protocol/ABI, semantics, and an adversarial one. The compatibility claims held up under harder testing than I had done — the message size is 544 before and after on gcc 4.9, 8.5 and 16.1, at several `-std` and `-O` levels and even under `-fpack-struct`, and 536 both ways on 32-bit; sm's regex was executed against the new output; and one pass linked the real IPC code against a simulated old tapdisk over a socketpair to confirm a new `tap-ctl` reads `error 0` rather than garbage. `job->ret` is read under `job_lock`, captured before the dismissal, and published under the same lock as the status.

They also found a defect that made the first commit not do its job, fixed in the second commit here:

- **The result was destroyed by reading it.** The query that observes `concluded` also dismisses the job, and the next query published a zero over the retained value — so one lost poll, one retry inside sm, or one operator running `tap-ctl query` by hand erased the failure permanently. The result is now kept until the next commit starts.
- `td_query_t` in the control path is now initialized: a future driver returning success without filling it would put stack garbage into the response — a bogus coalesce failure, or a dereference of a garbage status pointer.
- A `_Static_assert` now enforces the union-headroom invariant that makes this change safe to ship on its own. It was previously only a claim in a comment.
- `PRId32`, and the comment now says the value is a negative errno, which is what a parser needs to know.

## Known gaps, deliberately not fixed here

1. **`0` still conflates three states**: success, "no job ever started", and "result already consumed". `do_commit()` in particular returns success without starting a job when the top image is not found or there is no base to commit into, after which a query reports `undefined` / `0` and sm reads success. Fixing it properly means failing those early exits and distinguishing "no job ran" from "job finished and was reaped" — a semantic change to `tap-ctl commit`'s return that deserves its own commit and its own conversation with the sm side.
2. **Soft-cancelling a leaf coalesce that reached `READY` completes it** rather than abandoning it (`commit_active_cancel()` returns `force || !job_is_ready()`), and it then reports `error 0` — so sm can be told a cancel succeeded when the chain was in fact collapsed. Fixing this means either force-cancelling from that path, which discards work that was one step from finishing, or reporting the outcome accurately. That is a design call for the team, not one I should make unilaterally.
3. **Unrelated pre-existing bug found during review, worth its own fix:** `drivers/tapdisk-control.c` does `read(fd, message + offset, len - offset)` where `message` is a `tapdisk_message_t *`, so the offset is scaled by the struct size — any short read writes far past the buffer. Compare the correct `buf + offset` on a `void *` in `control/tap-ctl-ipc.c`. Not touched here to keep this PR focused.

## Open question for review

`job->ret` is passed as a plain errno-style integer. `job->err` also carries a message string, and review argues for carrying it: `job_update_rc_locked()` only synthesises `strerror(-ret)` when the driver left `err` unset, so for real driver failures the string holds strictly more than the errno — and `-EIO` alone does not tell an operator whether the *copy* failed (base half-written, chain intact) or the *header rewrite* failed (chain already re-pointed), which is exactly the distinction that decides whether re-pointing children is safe. There is room: the union has ~252 bytes of headroom, so a `char job_error_msg[]` after `job_error` keeps `sizeof` at 544. Adding it before anything parses the format is cheaper than a second format change later. I have not done it yet — say the word and I will.
