### PR TITLE
Fix lot of issues on commit

### DIFF
--- a/control/tap-ctl-list.c
+++ b/control/tap-ctl-list.c
@@ -85,7 +85,7 @@ _tap_list_free(tap_list_t *tl)
 int
 _parse_params(const char *params, char **type, char **path)
 {
-	char *ptr;
+	const char *ptr;
 	size_t len;
 
 	ptr = strchr(params, ':');

--- a/drivers/atomicio.c
+++ b/drivers/atomicio.c
@@ -36,11 +36,7 @@
  * ensure all of data on socket comes through. f==read || f==vwrite
  */
 size_t
-atomicio(f, fd, _s, n)
-	ssize_t (*f) (int, void *, size_t);
-	int fd;
-	void *_s;
-	size_t n;
+atomicio(ssize_t (*f) (int, void *, size_t), int fd, void *_s, size_t n)
 {
 	char *s = _s;
 	size_t pos = 0;

--- a/drivers/block-qcow2.c
+++ b/drivers/block-qcow2.c
@@ -166,6 +166,7 @@ struct qcow2_state {
 	pthread_mutex_t           lock;
 	pthread_cond_t            cond;
 	bool                      driver_opened;
+	bool                      handling_requests;
 	int                       open_status;
 	MemReentrancyGuard        mem_reentrancy_guard;
 
@@ -249,6 +250,13 @@ static void qcow2_handle_requests(struct qcow2_state *s)
 	struct qcow2_request *req;
 
 	pthread_mutex_lock(&s->lock);
+	if (s->handling_requests) {
+		/* Re-entered from inside a request handler: leave the
+		 * queue untouched, the outer loop below will drain it. */
+		pthread_mutex_unlock(&s->lock);
+		return;
+	}
+	s->handling_requests = true;
 	while ((req = QSIMPLEQ_FIRST(&s->inflight))) {
 		QSIMPLEQ_REMOVE_HEAD(&s->inflight, list);
 		pthread_mutex_unlock(&s->lock);
@@ -272,6 +280,7 @@ static void qcow2_handle_requests(struct qcow2_state *s)
 		}
 		pthread_mutex_lock(&s->lock);
 	}
+	s->handling_requests = false;
 	pthread_mutex_unlock(&s->lock);
 }
 

--- a/drivers/block-qcow2.c
+++ b/drivers/block-qcow2.c
@@ -469,6 +469,7 @@ qcow2_open(void *opaque)
 		 * everything it references is destroyed below.
 		 */
 		switch (bjob->job.status) {
+		case JOB_STATUS_CREATED:
 		case JOB_STATUS_RUNNING:
 		case JOB_STATUS_PAUSED:
 		case JOB_STATUS_READY:
@@ -1215,6 +1216,7 @@ do_cancel_commit_job(struct qcow2_state *s, struct qcow2_request *req)
 	 * runs on half-initialized or already-cleaned job state.
 	 */
 	switch (bjob->job.status) {
+	case JOB_STATUS_CREATED:
 	case JOB_STATUS_RUNNING:
 	case JOB_STATUS_PAUSED:
 	case JOB_STATUS_READY:

--- a/drivers/block-qcow2.c
+++ b/drivers/block-qcow2.c
@@ -440,8 +440,42 @@ qcow2_open(void *opaque)
 	}
 	pthread_mutex_unlock(&s->lock);
 
+	/*
+	 * Nothing must outlive this thread: the BlockBackend, the AioContext and
+	 * the driver state are all torn down below. A job that is still live
+	 * here would keep references to them, so cancel it before dismissing it.
+	 * job_dismiss_locked() only accepts a concluded job, which is why it used
+	 * to fail with "job dismiss error" and leave the job behind.
+	 */
 	job_lock();
 	BlockJob *bjob = block_job_get_locked(COMMIT_JOB_ID);
+	if (bjob) {
+		/*
+		 * Same restriction as do_cancel_commit_job(): only the states
+		 * where the job is started and stays alive on its own. The
+		 * transient finalization states cannot be observed here, because
+		 * the job is created with auto_finalize and this code runs with
+		 * an empty stack, not from the nested poll inside a finalize.
+		 * Force-cancel: this is the last chance to stop the job before
+		 * everything it references is destroyed below.
+		 */
+		switch (bjob->job.status) {
+		case JOB_STATUS_RUNNING:
+		case JOB_STATUS_PAUSED:
+		case JOB_STATUS_READY:
+		case JOB_STATUS_STANDBY: {
+			int cancel_err = job_cancel_sync_locked(&bjob->job, true);
+			if (cancel_err && cancel_err != -ECANCELED)
+				DPRINTF("Qcow2: job cancel error at close: %d\n", cancel_err);
+			break;
+		}
+		default:
+			break;
+		}
+
+		/* The cancel may have dismissed and freed the job already. */
+		bjob = block_job_get_locked(COMMIT_JOB_ID);
+	}
 	if (bjob) {
 		Job *job = &bjob->job;
 		job_dismiss_locked(&job, &local_err);
@@ -1137,13 +1171,52 @@ do_cancel_commit_job(struct qcow2_state *s, struct qcow2_request *req)
 		goto signal;
 	}
 
-	if (bjob->job.status == JOB_STATUS_RUNNING ||
-		bjob->job.status == JOB_STATUS_READY) {
+	/*
+	 * Cancel the job in every state where it is started and can stay alive
+	 * on its own. Restricting this to RUNNING and READY made the cancel a
+	 * silent no-op that still reported success for a paused or standby job,
+	 * and the caller (typically _qcow2_close()) then tore the BlockBackend
+	 * and the AioContext down underneath it.
+	 *
+	 * CREATED, WAITING, PENDING and ABORTING are deliberately excluded even
+	 * though the verb table allows some of them. The job is created with
+	 * auto_finalize, so those states only exist while commit_start() or the
+	 * finalization sequence is on the stack, and this handler can be reached
+	 * from the nested aio_bh_poll() that bdrv_graph_wrunlock() performs
+	 * inside them. Cancelling there re-enters job_finalize_single_locked()
+	 * on a job that is already being finalized: the job state machine
+	 * asserts, the transaction is unreferenced twice, and commit_abort()
+	 * runs on half-initialized or already-cleaned job state.
+	 */
+	switch (bjob->job.status) {
+	case JOB_STATUS_RUNNING:
+	case JOB_STATUS_PAUSED:
+	case JOB_STATUS_READY:
+	case JOB_STATUS_STANDBY:
 		if (req->sync == false) {
 			job_cancel_locked(&bjob->job, false);
 		} else {
+			/*
+			 * The job may be dismissed and freed by the cancel, so
+			 * bjob must not be used afterwards.
+			 */
 			err = job_cancel_sync_locked(&bjob->job, false);
 		}
+		break;
+	case JOB_STATUS_CONCLUDED:
+		/* Already finished, nothing left to cancel. */
+		DPRINTF("Qcow2: job already concluded.\n");
+		break;
+	default:
+		/*
+		 * Mid-finalization. Do not report this as a successful cancel:
+		 * the job is about to complete, and telling the caller it was
+		 * cancelled would have it believe the chain was left alone.
+		 */
+		DPRINTF("Qcow2: not cancelling job in state '%s'.\n",
+			JobStatus_str(bjob->job.status));
+		err = -EBUSY;
+		break;
 	}
 	job_unlock();
 

--- a/drivers/block-qcow2.c
+++ b/drivers/block-qcow2.c
@@ -588,11 +588,15 @@ _qcow2_close(td_driver_t *driver)
 
 	DBG(TLOG_WARN, "qcow2_close\n");
 
+        /*
+         * Kick while still holding the lock: the thread only checks
+         * driver_opened after taking s->lock, so kicking after unlock
+         * risks the bh/AioContext already being torn down.
+         */
 	pthread_mutex_lock(&s->lock);
 	s->driver_opened = false;
-	pthread_mutex_unlock(&s->lock);
-
 	qemu_bh_schedule(s->bh);
+	pthread_mutex_unlock(&s->lock);
 
 	// Ignore return, qcow2_open() always return NULL; or will abort
 	qemu_thread_join(&s->thread);

--- a/drivers/block-qcow2.c
+++ b/drivers/block-qcow2.c
@@ -110,6 +110,7 @@ struct qcow2_request;
 
 struct qcow2_request {
 	int                     error;
+	bool                    done;
 	enum qcow2_ops          op;
 	union {
 		/* OP_READ, OP_WRITE */
@@ -916,15 +917,17 @@ qcow2_commit(td_driver_t *driver, const char *name)
 
 	req->top   = strdup(name);
 	req->op    = QCOW2_OP_COMMIT;
+	req->done  = false;
 
 	pthread_mutex_lock(&s->lock);
 	QSIMPLEQ_INSERT_TAIL(&s->inflight, req, list);
 	pthread_mutex_unlock(&s->lock);
 
 	pthread_mutex_lock(&s->commit_lock);
-	qemu_bh_schedule(s->bh);
-
-	pthread_cond_wait(&s->commit_cond, &s->commit_lock);
+	if (!req->done) {
+		qemu_bh_schedule(s->bh);
+		pthread_cond_wait(&s->commit_cond, &s->commit_lock);
+	}
 	err = req->error;
 	pthread_mutex_unlock(&s->commit_lock);
 
@@ -977,6 +980,7 @@ do_commit(struct qcow2_state *s, struct qcow2_request *req)
 signal_commit:
 	pthread_mutex_lock(&s->commit_lock);
 	req->error = err;
+	req->done  = true;
 	pthread_cond_signal(&s->commit_cond);
 	pthread_mutex_unlock(&s->commit_lock);
 }
@@ -995,15 +999,17 @@ qcow2_query_commit_job(td_driver_t *driver, td_query_t *query)
 		return -EBUSY;
 
 	req->op    = QCOW2_OP_QUERY;
+	req->done  = false;
 
 	pthread_mutex_lock(&s->lock);
 	QSIMPLEQ_INSERT_TAIL(&s->inflight, req, list);
 	pthread_mutex_unlock(&s->lock);
 
 	pthread_mutex_lock(&s->commit_lock);
-	qemu_bh_schedule(s->bh);
-
-	pthread_cond_wait(&s->commit_cond, &s->commit_lock);
+	if (!req->done) {
+		qemu_bh_schedule(s->bh);
+		pthread_cond_wait(&s->commit_cond, &s->commit_lock);
+	}
 
 	if (query) {
 		query->status = JobStatus_str(s->job_info.status);
@@ -1071,6 +1077,7 @@ signal:
 	s->job_info.total_progress = total;
 
 	req->error = err;
+	req->done  = true;
 	pthread_cond_signal(&s->commit_cond);
 	pthread_mutex_unlock(&s->commit_lock);
 }
@@ -1091,15 +1098,17 @@ qcow2_cancel_commit_job(td_driver_t *driver, bool wait)
 
 	req->op   = QCOW2_OP_CANCEL_COMMIT;
 	req->sync = wait;
+	req->done = false;
 
 	pthread_mutex_lock(&s->lock);
 	QSIMPLEQ_INSERT_TAIL(&s->inflight, req, list);
 	pthread_mutex_unlock(&s->lock);
 
 	pthread_mutex_lock(&s->commit_lock);
-	qemu_bh_schedule(s->bh);
-
-	pthread_cond_wait(&s->commit_cond, &s->commit_lock);
+	if (!req->done) {
+		qemu_bh_schedule(s->bh);
+		pthread_cond_wait(&s->commit_cond, &s->commit_lock);
+	}
 	err = req->error;
 	pthread_mutex_unlock(&s->commit_lock);
 
@@ -1143,6 +1152,7 @@ do_cancel_commit_job(struct qcow2_state *s, struct qcow2_request *req)
 signal:
 	pthread_mutex_lock(&s->commit_lock);
 	req->error = err;
+	req->done  = true;
 	pthread_cond_signal(&s->commit_cond);
 	pthread_mutex_unlock(&s->commit_lock);
 }

--- a/drivers/block-qcow2.c
+++ b/drivers/block-qcow2.c
@@ -562,6 +562,19 @@ _qcow2_open(td_driver_t *driver, const char *name,
 	s->open_status = 0;
 	pthread_mutex_unlock(&s->lock);
 
+	if (err) {
+		/*
+                 * Join the teardown thread before returning so a retried
+                 * open doesn't reinit QEMU globals while it's still running.
+		 */
+		qemu_thread_join(&s->thread);
+
+		pthread_cond_destroy(&s->commit_cond);
+		pthread_mutex_destroy(&s->commit_lock);
+		pthread_cond_destroy(&s->cond);
+		pthread_mutex_destroy(&s->lock);
+	}
+
 	return err;
 }
 

--- a/drivers/tapdisk-disktype.c
+++ b/drivers/tapdisk-disktype.c
@@ -221,7 +221,8 @@ tapdisk_disktype_find(const char *name)
 int
 tapdisk_disktype_parse_params(const char *params, const char **_path)
 {
-	char name[DISK_TYPE_NAME_MAX], *ptr;
+	char name[DISK_TYPE_NAME_MAX];
+	const char *ptr;
 	size_t len;
 	int type;
 

--- a/drivers/td-blkif.c
+++ b/drivers/td-blkif.c
@@ -265,6 +265,8 @@ tapdisk_xenblkif_destroy(struct td_xenblkif * blkif)
         err = 0;
     }
 
+    pthread_mutex_destroy(&blkif->mutex_chkrng);
+
     free(blkif);
 
     return err;
@@ -381,7 +383,17 @@ tapdisk_xenblkif_cb_stoppolling(event_id_t id __attribute__((unused)),
         /* If there were no new requests this time, then stop polling */
         blkif->in_polling = false;
 
-        /* Stop obsessively checking the ring */
+        /*
+         * Stop obsessively checking the ring.
+         *
+         * NB. we may get here with requests still in the ring, left behind an
+         * in-flight barrier request: process_ring() gives up on the ring while
+         * a barrier is armed, and does not re-arm front-end notifications. The
+         * ring check requested by the barrier's completion is then the only
+         * thing that will bring us back to the ring, and the driver thread may
+         * request it right here, between the process_ring() above and this
+         * line. tapdisk_xenblkif_unsched_chkrng() is careful not to cancel it.
+         */
         tapdisk_xenblkif_unsched_chkrng(blkif);
 
         /* Make the 'stop polling' event not fire again */
@@ -392,11 +404,16 @@ tapdisk_xenblkif_cb_stoppolling(event_id_t id __attribute__((unused)),
 }
 
 void
-tapdisk_xenblkif_sched_chkrng(const struct td_xenblkif *blkif)
+tapdisk_xenblkif_sched_chkrng(struct td_xenblkif *blkif)
 {
 	int err;
 
 	ASSERT(blkif);
+
+	/* Raise before arming */
+	pthread_mutex_lock(&blkif->mutex_chkrng);
+	blkif->chkrng_pending = true;
+	pthread_mutex_unlock(&blkif->mutex_chkrng);
 
 	err = tapdisk_server_event_set_timeout(
 			tapdisk_xenblkif_chkrng_event_id(blkif), TV_ZERO);
@@ -404,15 +421,23 @@ tapdisk_xenblkif_sched_chkrng(const struct td_xenblkif *blkif)
 }
 
 void
-tapdisk_xenblkif_unsched_chkrng(const struct td_xenblkif *blkif)
+tapdisk_xenblkif_unsched_chkrng(struct td_xenblkif *blkif)
 {
 	int err;
 
 	ASSERT(blkif);
 
-	err = tapdisk_server_event_set_timeout(
-			tapdisk_xenblkif_chkrng_event_id(blkif), TV_INF);
-	ASSERT(!err);
+	/*
+         * A driver thread may have requested a ring check, do not disarm the
+         * event. That request may be the only one this ring will ever get.
+	 */
+	pthread_mutex_lock(&blkif->mutex_chkrng);
+	if (likely(!blkif->chkrng_pending)) {
+		err = tapdisk_server_event_set_timeout(
+				tapdisk_xenblkif_chkrng_event_id(blkif), TV_INF);
+		ASSERT(!err);
+	}
+	pthread_mutex_unlock(&blkif->mutex_chkrng);
 }
 
 static inline void
@@ -422,6 +447,11 @@ tapdisk_xenblkif_cb_chkrng(event_id_t id __attribute__((unused)),
     struct td_xenblkif *blkif = private;
 
     ASSERT(blkif);
+
+    /* We are about to look at the ring, acknowledge chkrng */
+    pthread_mutex_lock(&blkif->mutex_chkrng);
+    blkif->chkrng_pending = false;
+    pthread_mutex_unlock(&blkif->mutex_chkrng);
 
     /*
      * If we are polling, process the ring without setting the event counter.
@@ -486,6 +516,8 @@ tapdisk_xenblkif_connect(domid_t domid, int devid, const grant_ref_t * grefs,
 	td_blkif->barrier.msg = NULL;
 	td_blkif->barrier.io_done = false;
 	td_blkif->barrier.io_err = 0;
+    td_blkif->chkrng_pending = false;
+    pthread_mutex_init(&td_blkif->mutex_chkrng, NULL);
 
     td_blkif->xenvbd_stats.root = NULL;
     shm_init(&td_blkif->xenvbd_stats.io_ring);

--- a/drivers/td-blkif.h
+++ b/drivers/td-blkif.h
@@ -198,6 +198,27 @@ struct td_xenblkif {
 	event_id_t chkrng_event;
 	event_id_t stoppolling_event;
 
+	/**
+	 * Tells whether a ring check has been requested but not performed yet.
+	 *
+	 * When we give up on the ring with requests still in it (we stopped at a
+	 * barrier request, or we ran out of free request slots) we do not re-arm
+	 * the ring for front-end notifications, so the guest goes silent. The ring
+	 * check requested at that point is then the only thing that will bring us
+	 * back to the ring, and losing it stalls the ring for good.
+	 *
+	 * Completions may run in a driver thread (see TD_DRIVER_THREADED, e.g.
+	 * qcow2) and request a ring check while the main thread is unscheduling
+	 * one, so this flag records the request and keeps the unschedule from
+	 * cancelling a request it has not honoured.
+	 *
+	 * Accessed with __atomic_* (SEQ_CST), not under @mutex: what makes the
+	 * request safe is its ordering against the arming of the event, and
+	 * sched/unsched are called both with and without @mutex held.
+	 */
+	bool chkrng_pending;
+	pthread_mutex_t mutex_chkrng;
+
 	bool in_polling;
 	int poll_duration; /* microseconds; 0 means no polling. */
 	int poll_idle_threshold;
@@ -336,16 +357,19 @@ void
 tapdisk_start_polling(struct td_xenblkif *blkif);
 
 /**
- * Schedules a ring check.
+ * Schedules a ring check. Safe to call from any thread: the request is recorded
+ * in @blkif->chkrng_pending so that a concurrent
+ * tapdisk_xenblkif_unsched_chkrng() cannot cancel it.
  */
 void
-tapdisk_xenblkif_sched_chkrng(const struct td_xenblkif *blkif);
+tapdisk_xenblkif_sched_chkrng(struct td_xenblkif *blkif);
 
 /**
- * Unschedules the ring check.
+ * Unschedules the ring check, unless a ring check has been requested and not
+ * honoured yet, in which case the event is left armed.
  */
 void
-tapdisk_xenblkif_unsched_chkrng(const struct td_xenblkif *blkif);
+tapdisk_xenblkif_unsched_chkrng(struct td_xenblkif *blkif);
 
 /**
  * Tells whether a barrier request can be completed.

--- a/qcow2/lib/block/commit.c
+++ b/qcow2/lib/block/commit.c
@@ -98,10 +98,6 @@ static void commit_abort(Job *job)
      * after the failed/cancelled commit job is gone? If we already wrote
      * something to base, the intermediate images aren't valid any more. */
     bdrv_graph_rdlock_main_loop();
-    if (!s->commit_top_bs->backing) {
-        bdrv_graph_rdunlock_main_loop();
-        return;
-    }
     commit_top_backing_bs = s->commit_top_bs->backing->bs;
     bdrv_graph_rdunlock_main_loop();
 
@@ -128,6 +124,13 @@ static void commit_clean(Job *job)
 
     g_free(s->backing_file_str);
     blk_unref(s->top);
+
+    /*
+     * Release the reference taken in commit_start(). On the success path the
+     * filter node is already detached from its parents, so this is the last
+     * reference to it.
+     */
+    bdrv_unref(s->commit_top_bs);
 }
 
 static int coroutine_fn commit_run(Job *job, Error **errp)
@@ -330,12 +333,21 @@ void commit_start(const char *job_id, BlockDriverState *bs,
     commit_top_bs->total_sectors = top->total_sectors;
 
     ret = bdrv_append(commit_top_bs, top, errp);
-    bdrv_unref(commit_top_bs); /* referenced by new parents or failed */
     if (ret < 0) {
+        bdrv_unref(commit_top_bs);
         commit_top_bs = NULL;
         goto fail;
     }
 
+    /*
+     * Keep the creation reference for the whole lifetime of the job instead of
+     * relying on the parent links alone: bdrv_drop_intermediate() moves those
+     * parents to base and then drops the last reference, which deletes the
+     * node while s->commit_top_bs still points at it. commit_abort() would
+     * then run on freed memory.
+     * The reference is released in commit_clean() (or in the fail branch of
+     * this function if it fails).
+     */
     s->commit_top_bs = commit_top_bs;
 
     /*
@@ -446,6 +458,11 @@ fail:
         bdrv_replace_node(commit_top_bs, top, &error_abort);
         bdrv_graph_wrunlock();
         bdrv_drained_end(top);
+        /*
+         * commit_clean() does not run for a job that failed to start, so the
+         * reference kept for the job lifetime is released here.
+         */
+        bdrv_unref(commit_top_bs);
     }
 }
 

--- a/qcow2/lib/util/main-loop.c
+++ b/qcow2/lib/util/main-loop.c
@@ -208,6 +208,19 @@ int qemu_deinit_main_loop(void)
 {
     GSource *src;
 
+    /*
+     * Delete qemu_notify_bh and sigfd first, while qemu_aio_context is still
+     * guaranteed alive.
+     */
+    qemu_bh_delete(qemu_notify_bh);
+    qemu_notify_bh = NULL;
+
+    if (sigfd != -1) {
+        aio_set_fd_handler(iohandler_get_aio_context(), sigfd, NULL, NULL, NULL, NULL, NULL);
+        close(sigfd);
+        sigfd = -1;
+    }
+
     src = iohandler_get_g_source();
     g_source_unref(src);
     g_source_destroy(src);
@@ -219,15 +232,6 @@ int qemu_deinit_main_loop(void)
     g_source_unref(src);
 
     g_array_free(gpollfds, TRUE);
-
-    qemu_bh_delete(qemu_notify_bh);
-    qemu_notify_bh = NULL;
-
-    if (sigfd != -1) {
-        aio_set_fd_handler(iohandler_get_aio_context(), sigfd, NULL, NULL, NULL, NULL, NULL);
-        close(sigfd);
-        sigfd = -1;
-    }
 
     iohandler_deinit();
     qemu_aio_context = NULL;

--- a/qcow2/lib/util/qemu-sockets.c
+++ b/qcow2/lib/util/qemu-sockets.c
@@ -596,7 +596,7 @@ err:
 static int inet_parse_flag(const char *flagname, const char *optstr, bool *val,
                            Error **errp)
 {
-    char *end;
+    const char *end;
     size_t len;
 
     end = strstr(optstr, ",");
@@ -627,7 +627,7 @@ int inet_parse(InetSocketAddress *addr, const char *str, Error **errp)
     char port[33];
     int to;
     int pos;
-    char *begin;
+    const char *begin;
 
     memset(addr, 0, sizeof(*addr));
 

--- a/vhd/lib/atomicio.c
+++ b/vhd/lib/atomicio.c
@@ -36,11 +36,7 @@
  * ensure all of data on socket comes through. f==read || f==vwrite
  */
 size_t
-atomicio(f, fd, _s, n)
-	ssize_t (*f) (int, void *, size_t);
-	int fd;
-	void *_s;
-	size_t n;
+atomicio(ssize_t (*f) (int, void *, size_t), int fd, void *_s, size_t n)
 {
 	char *s = _s;
 	size_t pos = 0;

--- a/vhd/lib/vhd-util-check.c
+++ b/vhd/lib/vhd-util-check.c
@@ -158,7 +158,7 @@ pct(uint64_t num, uint64_t den)
 static inline char *
 name(const char *path)
 {
-	char *p = strrchr(path, '/');
+	const char *p = strrchr(path, '/');
 	if (p && (p - path) == strlen(path))
 		p = strrchr(--p, '/');
 	return (char *)(p ? ++p : path);

--- a/vhd/lib/vhd-util-scan.c
+++ b/vhd/lib/vhd-util-scan.c
@@ -491,7 +491,8 @@ vhd_util_scan_extract_volume_name(char *dst, const char *src, size_t size)
 		return -EINVAL;
 	}
 
-	char copy[VHD_MAX_NAME_LEN], *name, *s, *c;
+	char copy[VHD_MAX_NAME_LEN], *c;
+	const char *name, *s;
 
 	name = strrchr(src, '/');
 	if (!name)


### PR DESCRIPTION
- 3 fixes to compile on modern gcc.
- Fix use-after-free of `commit_top_bs` in `commit_abort()`.
- Fix lost wakeups in commit/query/cancel commands.
- Handle all job states in cancel.
- Join thread and cleanup on failed open.
- Fix use-after-free of `s->bh` in commit command.
- Stop a commit job to outliving driver close.
- Cancel a `created` job.
- fix use-after-free in `qemu-deinit_main_loop()`.