### PR TITLE
qcow2: force thread naming

### DIFF
--- a/drivers/block-qcow2.c
+++ b/drivers/block-qcow2.c
@@ -519,6 +519,7 @@ _qcow2_open(td_driver_t *driver, const char *name,
 
 	pthread_mutex_lock(&s->lock);
 	s->driver_opened = true;
+	qemu_thread_naming(true);
 	qemu_thread_create(&s->thread, "td-qcow2", qcow2_open, s,
 			   QEMU_THREAD_JOINABLE);
 

--- a/qcow2/lib/util/qemu-thread-posix.c
+++ b/qcow2/lib/util/qemu-thread-posix.c
@@ -22,7 +22,7 @@
 #include <pthread_np.h>
 #endif
 
-static bool name_threads;
+static bool name_threads = true;
 
 void qemu_thread_naming(bool enable)
 {


### PR DESCRIPTION
Useful for differentiate CPU load.
Call to qemu_thread_naming() should be sufficient, but RCU thread
won't be named. So until we remove RCU thread, setting variable to
true is required.